### PR TITLE
feat(sns): X OAuth 1.0a authentication with abstract provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "twitter-api-v2": "^1.29.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      twitter-api-v2:
+        specifier: ^1.29.0
+        version: 1.29.0
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1947,6 +1950,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  twitter-api-v2@1.29.0:
+    resolution: {integrity: sha512-v473q5bwme4N+DWSg6qY+JCvfg1nSJRWwui3HUALafxfqCvVkKiYmS/5x/pVeJwTmyeBxexMbzHwnzrH4h6oYQ==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -4089,6 +4095,8 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  twitter-api-v2@1.29.0: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/app/api/auth/x/callback/route.ts
+++ b/src/app/api/auth/x/callback/route.ts
@@ -1,9 +1,111 @@
-// OAuth callback — implemented in Directive ③
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { XProvider } from "@/lib/providers/x.provider";
+import { encrypt } from "@/utils/token-encryption";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { TwitterApi } from "twitter-api-v2";
 
-export async function GET() {
-  return NextResponse.json(
-    { message: "X OAuth callback — not yet implemented" },
-    { status: 501 },
-  );
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = request.nextUrl;
+    const oauthToken = searchParams.get("oauth_token");
+    const oauthVerifier = searchParams.get("oauth_verifier");
+
+    if (!oauthToken || !oauthVerifier) {
+      return NextResponse.json(
+        {
+          error: "Missing oauth_token or oauth_verifier",
+          code: "INVALID_CALLBACK",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Retrieve the stored oauth_token_secret
+    const cookieStore = await cookies();
+    const oauthTokenSecret = cookieStore.get("x_oauth_token_secret")?.value;
+
+    if (!oauthTokenSecret) {
+      return NextResponse.json(
+        {
+          error: "OAuth session expired. Please try again.",
+          code: "SESSION_EXPIRED",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Exchange for access token
+    const provider = new XProvider();
+    const callbackCode = [oauthToken, oauthTokenSecret, oauthVerifier].join(
+      ":",
+    );
+    const token = await provider.handleCallback(callbackCode, "");
+
+    // Fetch X user profile to get userId and username
+    const apiKey = process.env.X_API_KEY!;
+    const apiSecret = process.env.X_API_SECRET!;
+    const userClient = new TwitterApi({
+      appKey: apiKey,
+      appSecret: apiSecret,
+      accessToken: token.accessToken,
+      accessSecret: token.accessSecret,
+    });
+    const { data: xUser } = await userClient.v2.me();
+
+    // Encrypt tokens before storage
+    const encryptedAccessToken = encrypt(token.accessToken);
+    const encryptedAccessSecret = encrypt(token.accessSecret ?? "");
+
+    // Get authenticated Supabase user
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Not authenticated", code: "AUTH_REQUIRED" },
+        { status: 401 },
+      );
+    }
+
+    // Upsert the platform connection
+    const { error: dbError } = await supabase
+      .from("sns_platform_connections")
+      .upsert(
+        {
+          user_id: user.id,
+          platform: "x",
+          encrypted_access_token: encryptedAccessToken,
+          encrypted_access_secret: encryptedAccessSecret,
+          platform_user_id: xUser.id,
+          platform_username: xUser.username,
+          status: "active",
+          connected_at: new Date().toISOString(),
+        },
+        { onConflict: "user_id,platform" },
+      );
+
+    if (dbError) {
+      console.error("[X OAuth Callback] DB error:", dbError);
+      return NextResponse.json(
+        { error: "Failed to save connection", code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    // Clean up the temporary cookie
+    cookieStore.delete("x_oauth_token_secret");
+
+    // Redirect to settings with success
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+    return NextResponse.redirect(`${baseUrl}/dashboard/settings?connected=x`);
+  } catch (err) {
+    console.error("[X OAuth Callback]", err);
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL ?? "";
+    return NextResponse.redirect(
+      `${baseUrl}/dashboard/settings?error=x_oauth_failed`,
+    );
+  }
 }

--- a/src/app/api/auth/x/route.ts
+++ b/src/app/api/auth/x/route.ts
@@ -1,9 +1,47 @@
-// OAuth start (redirect) — implemented in Directive ③
 import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { XProvider } from "@/lib/providers/x.provider";
 
 export async function GET() {
-  return NextResponse.json(
-    { message: "X OAuth start — not yet implemented" },
-    { status: 501 },
-  );
+  try {
+    const provider = new XProvider();
+
+    const baseUrl = process.env.NEXT_PUBLIC_APP_URL;
+    if (!baseUrl) {
+      return NextResponse.json(
+        {
+          error: "NEXT_PUBLIC_APP_URL is not configured",
+          code: "CONFIG_ERROR",
+        },
+        { status: 500 },
+      );
+    }
+
+    const redirectUri = `${baseUrl}/api/auth/x/callback`;
+
+    // getAuthUrl returns "authUrl\noauthToken\noauthTokenSecret"
+    const packed = await provider.getAuthUrl("", redirectUri);
+    const [authUrl, , oauthTokenSecret] = packed.split("\n");
+
+    // Store the oauth_token_secret in an httpOnly cookie for the callback
+    const cookieStore = await cookies();
+    cookieStore.set("x_oauth_token_secret", oauthTokenSecret, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      maxAge: 600, // 10 minutes
+      path: "/",
+    });
+
+    return NextResponse.redirect(authUrl);
+  } catch (err) {
+    console.error("[X OAuth Start]", err);
+    return NextResponse.json(
+      {
+        error: err instanceof Error ? err.message : "Failed to start X OAuth",
+        code: "OAUTH_START_ERROR",
+      },
+      { status: 500 },
+    );
+  }
 }

--- a/src/lib/providers/base.provider.ts
+++ b/src/lib/providers/base.provider.ts
@@ -1,2 +1,24 @@
-// Abstract SocialMediaProvider — implemented in Directive ③
-export {};
+import type {
+  PlatformType,
+  OAuthToken,
+  PublishResult,
+  PostContent,
+} from "@/types/platform";
+
+export abstract class SocialMediaProvider {
+  abstract readonly platform: PlatformType;
+
+  abstract getAuthUrl(userId: string, redirectUri: string): Promise<string>;
+  abstract handleCallback(
+    code: string,
+    redirectUri: string,
+  ): Promise<OAuthToken>;
+  abstract refreshToken(token: OAuthToken): Promise<OAuthToken>;
+  abstract publishPost(
+    token: OAuthToken,
+    content: PostContent,
+  ): Promise<PublishResult>;
+  abstract validateToken(token: OAuthToken): Promise<boolean>;
+
+  abstract getRateLimitInfo(): { type: string; limit: number; window: string };
+}

--- a/src/lib/providers/x.provider.ts
+++ b/src/lib/providers/x.provider.ts
@@ -1,2 +1,132 @@
-// X (Twitter) provider — implemented in Directive ③ / ⑦
-export {};
+import { TwitterApi } from "twitter-api-v2";
+import { SocialMediaProvider } from "@/lib/providers/base.provider";
+import type {
+  PlatformType,
+  OAuthToken,
+  PublishResult,
+  PostContent,
+} from "@/types/platform";
+
+function getAppKeys() {
+  const apiKey = process.env.X_API_KEY;
+  const apiSecret = process.env.X_API_SECRET;
+  if (!apiKey || !apiSecret) {
+    throw new Error("X_API_KEY and X_API_SECRET must be set in environment.");
+  }
+  return { apiKey, apiSecret };
+}
+
+export class XProvider extends SocialMediaProvider {
+  readonly platform: PlatformType = "x";
+
+  /**
+   * Generate an OAuth 1.0a request token and return the authorization URL.
+   * The returned URL string also encodes the oauthTokenSecret in the hash
+   * so the caller can persist it (e.g. in a cookie).
+   *
+   * Returns: `authUrl\noauthToken\noauthTokenSecret` — caller splits on '\n'.
+   */
+  async getAuthUrl(_userId: string, redirectUri: string): Promise<string> {
+    const { apiKey, apiSecret } = getAppKeys();
+    const client = new TwitterApi({ appKey: apiKey, appSecret: apiSecret });
+
+    const { url, oauth_token, oauth_token_secret } =
+      await client.generateAuthLink(redirectUri, { linkMode: "authorize" });
+
+    // Pack URL + token + secret so the route handler can store the secret
+    return [url, oauth_token, oauth_token_secret].join("\n");
+  }
+
+  /**
+   * Exchange the oauth_verifier for a permanent access token.
+   * `code` is `oauthToken:oauthTokenSecret:oauthVerifier` joined by ':'.
+   * `redirectUri` is unused for OAuth 1.0a exchange but kept for interface compat.
+   */
+  async handleCallback(
+    code: string,
+    _redirectUri: string,
+  ): Promise<OAuthToken> {
+    const [oauthToken, oauthTokenSecret, oauthVerifier] = code.split(":");
+    if (!oauthToken || !oauthTokenSecret || !oauthVerifier) {
+      throw new Error(
+        "Invalid callback code. Expected 'oauthToken:oauthTokenSecret:oauthVerifier'.",
+      );
+    }
+
+    const { apiKey, apiSecret } = getAppKeys();
+    const tempClient = new TwitterApi({
+      appKey: apiKey,
+      appSecret: apiSecret,
+      accessToken: oauthToken,
+      accessSecret: oauthTokenSecret,
+    });
+
+    const { accessToken, accessSecret } = await tempClient.login(oauthVerifier);
+
+    return {
+      accessToken,
+      accessSecret,
+    };
+  }
+
+  /**
+   * OAuth 1.0a tokens do not expire / cannot be refreshed.
+   * Return the same token unchanged.
+   */
+  async refreshToken(token: OAuthToken): Promise<OAuthToken> {
+    return token;
+  }
+
+  async publishPost(
+    token: OAuthToken,
+    content: PostContent,
+  ): Promise<PublishResult> {
+    try {
+      const { apiKey, apiSecret } = getAppKeys();
+      const client = new TwitterApi({
+        appKey: apiKey,
+        appSecret: apiSecret,
+        accessToken: token.accessToken,
+        accessSecret: token.accessSecret,
+      });
+
+      const text = content.hashtags?.length
+        ? `${content.text}\n\n${content.hashtags.map((t) => `#${t}`).join(" ")}`
+        : content.text;
+
+      const { data } = await client.v2.tweet(text);
+
+      return {
+        success: true,
+        platformPostId: data.id,
+        platformUrl: `https://x.com/i/status/${data.id}`,
+      };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  async validateToken(token: OAuthToken): Promise<boolean> {
+    try {
+      const { apiKey, apiSecret } = getAppKeys();
+      const client = new TwitterApi({
+        appKey: apiKey,
+        appSecret: apiSecret,
+        accessToken: token.accessToken,
+        accessSecret: token.accessSecret,
+      });
+
+      await client.v2.me();
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  getRateLimitInfo() {
+    return { type: "monthly", limit: 500, window: "30d" };
+  }
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,2 +1,23 @@
-// Supabase server client (cookies) — implemented in Directive ④
-export {};
+import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function createSupabaseServerClient() {
+  const cookieStore = await cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return cookieStore.getAll();
+        },
+        setAll(cookiesToSet) {
+          for (const { name, value, options } of cookiesToSet) {
+            cookieStore.set(name, value, options);
+          }
+        },
+      },
+    },
+  );
+}

--- a/src/types/platform.ts
+++ b/src/types/platform.ts
@@ -1,2 +1,37 @@
-// Platform types (PlatformType, OAuthToken, etc.) — implemented in Directive ③
-export {};
+export type PlatformType =
+  | "x"
+  | "instagram"
+  | "tiktok"
+  | "youtube"
+  | "linkedin";
+
+export interface OAuthToken {
+  accessToken: string;
+  refreshToken?: string;
+  expiresAt?: Date;
+  accessSecret?: string; // X OAuth 1.0a
+}
+
+export interface PlatformConnection {
+  id: string;
+  userId: string;
+  platform: PlatformType;
+  token: OAuthToken;
+  platformUserId: string;
+  platformUsername: string;
+  status: "active" | "expired" | "revoked";
+}
+
+export interface PublishResult {
+  success: boolean;
+  platformPostId?: string;
+  platformUrl?: string;
+  error?: string;
+}
+
+export interface PostContent {
+  text: string;
+  mediaUrls?: string[];
+  hashtags?: string[];
+  scheduledAt?: Date;
+}

--- a/src/utils/token-encryption.ts
+++ b/src/utils/token-encryption.ts
@@ -1,2 +1,74 @@
-// AES-256-GCM token encryption — implemented in Directive ③
-export {};
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+const AUTH_TAG_LENGTH = 16;
+
+function getEncryptionKey(): Buffer {
+  const hex = process.env.TOKEN_ENCRYPTION_KEY;
+  if (!hex) {
+    throw new Error(
+      "TOKEN_ENCRYPTION_KEY is not set. Provide a 32-byte hex string (64 hex chars).",
+    );
+  }
+  if (hex.length !== 64) {
+    throw new Error(
+      `TOKEN_ENCRYPTION_KEY must be 64 hex characters (32 bytes). Got ${hex.length} characters.`,
+    );
+  }
+  return Buffer.from(hex, "hex");
+}
+
+/**
+ * Encrypt plaintext using AES-256-GCM.
+ * Returns a string in the format `iv:authTag:ciphertext` (all base64).
+ */
+export function encrypt(plaintext: string): string {
+  const key = getEncryptionKey();
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const authTag = cipher.getAuthTag();
+
+  return [
+    iv.toString("base64"),
+    authTag.toString("base64"),
+    encrypted.toString("base64"),
+  ].join(":");
+}
+
+/**
+ * Decrypt a string produced by `encrypt`.
+ * Expects the format `iv:authTag:ciphertext` (all base64).
+ */
+export function decrypt(encrypted: string): string {
+  const parts = encrypted.split(":");
+  if (parts.length !== 3) {
+    throw new Error(
+      'Invalid encrypted format. Expected "iv:authTag:ciphertext" (base64).',
+    );
+  }
+
+  const key = getEncryptionKey();
+  const iv = Buffer.from(parts[0], "base64");
+  const authTag = Buffer.from(parts[1], "base64");
+  const ciphertext = Buffer.from(parts[2], "base64");
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv, {
+    authTagLength: AUTH_TAG_LENGTH,
+  });
+  decipher.setAuthTag(authTag);
+
+  const decrypted = Buffer.concat([
+    decipher.update(ciphertext),
+    decipher.final(),
+  ]);
+
+  return decrypted.toString("utf8");
+}


### PR DESCRIPTION
## Summary
- Implement abstract `SocialMediaProvider` base class for multi-platform OAuth support
- Add `XProvider` with full OAuth 1.0a flow (auth link generation, token exchange, tweet publishing, token validation)
- Implement AES-256-GCM token encryption (`iv:authTag:ciphertext` format) — tokens are never stored in plaintext
- Add `/api/auth/x` start endpoint and `/api/auth/x/callback` callback endpoint
- Create platform types (`PlatformType`, `OAuthToken`, `PlatformConnection`, `PublishResult`, `PostContent`)
- Implement Supabase server client for Next.js App Router cookie-based auth

## Files Changed
| File | Purpose |
|------|---------|
| `src/types/platform.ts` | Platform type definitions |
| `src/lib/providers/base.provider.ts` | Abstract SocialMediaProvider class |
| `src/lib/providers/x.provider.ts` | X (Twitter) OAuth 1.0a provider |
| `src/utils/token-encryption.ts` | AES-256-GCM encrypt/decrypt |
| `src/lib/supabase/server.ts` | Supabase server client |
| `src/app/api/auth/x/route.ts` | OAuth start (redirect to X) |
| `src/app/api/auth/x/callback/route.ts` | OAuth callback (token exchange + save) |

## Required Environment Variables
- `X_API_KEY` / `X_API_SECRET` — X app credentials
- `TOKEN_ENCRYPTION_KEY` — 32-byte hex string for AES-256-GCM
- `NEXT_PUBLIC_APP_URL` — Base URL for OAuth redirects
- `NEXT_PUBLIC_SUPABASE_URL` / `NEXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase config

## Test plan
- [ ] Verify `pnpm build` passes (confirmed locally)
- [ ] Set environment variables and test OAuth flow end-to-end
- [ ] Verify tokens are encrypted in `sns_platform_connections` table
- [ ] Verify token decryption roundtrip with `encrypt`/`decrypt`
- [ ] Test error cases: missing env vars, expired OAuth session, invalid verifier

🤖 Generated with [Claude Code](https://claude.com/claude-code)