### PR TITLE
feat(sns): Posts CRUD API endpoints

### DIFF
--- a/src/app/api/posts/[id]/approve/route.ts
+++ b/src/app/api/posts/[id]/approve/route.ts
@@ -1,9 +1,71 @@
-// POST (approve) — implemented in Directive ④
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
-export async function POST() {
-  return NextResponse.json(
-    { message: "Approve post — not yet implemented" },
-    { status: 501 },
-  );
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // Check post exists and belongs to user
+    const { data: post, error: fetchError } = await supabase
+      .from("sns_posts")
+      .select("status")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (fetchError || !post) {
+      return NextResponse.json(
+        { error: "Post not found", code: "NOT_FOUND" },
+        { status: 404 },
+      );
+    }
+
+    if (post.status !== "pending_approval") {
+      return NextResponse.json(
+        {
+          error: "Can only approve posts with pending_approval status",
+          code: "INVALID_STATUS",
+        },
+        { status: 409 },
+      );
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from("sns_posts")
+      .update({
+        status: "approved",
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (updateError) {
+      return NextResponse.json(
+        { error: updateError.message, code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(updated);
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/posts/[id]/publish/route.ts
+++ b/src/app/api/posts/[id]/publish/route.ts
@@ -1,9 +1,115 @@
-// POST (publish to queue) — implemented in Directive ④ / ⑦
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
-export async function POST() {
-  return NextResponse.json(
-    { message: "Publish post — not yet implemented" },
-    { status: 501 },
-  );
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function POST(_request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // Check post exists and belongs to user
+    const { data: post, error: fetchError } = await supabase
+      .from("sns_posts")
+      .select("status, scheduled_at")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (fetchError || !post) {
+      return NextResponse.json(
+        { error: "Post not found", code: "NOT_FOUND" },
+        { status: 404 },
+      );
+    }
+
+    if (post.status !== "approved" && post.status !== "scheduled") {
+      return NextResponse.json(
+        {
+          error: "Can only publish posts with approved or scheduled status",
+          code: "INVALID_STATUS",
+        },
+        { status: 409 },
+      );
+    }
+
+    // Determine target status based on scheduled_at
+    const isScheduled =
+      post.scheduled_at && new Date(post.scheduled_at) > new Date();
+    const newStatus = isScheduled ? "scheduled" : "publishing";
+
+    // Update post status
+    const { error: updateError } = await supabase
+      .from("sns_posts")
+      .update({
+        status: newStatus,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", id)
+      .eq("user_id", user.id);
+
+    if (updateError) {
+      return NextResponse.json(
+        { error: updateError.message, code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    // Get target platforms from adaptations
+    const { data: adaptations } = await supabase
+      .from("sns_post_adaptations")
+      .select("platform")
+      .eq("post_id", id);
+
+    if (!adaptations || adaptations.length === 0) {
+      return NextResponse.json(
+        {
+          error: "No platform adaptations found for this post",
+          code: "VALIDATION_ERROR",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Create publish records for each target platform
+    const publishRecords = adaptations.map((a) => ({
+      post_id: id,
+      platform: a.platform,
+      status: "pending" as const,
+      retry_count: 0,
+    }));
+
+    const { data: publishes, error: publishError } = await supabase
+      .from("sns_post_publishes")
+      .insert(publishRecords)
+      .select();
+
+    if (publishError) {
+      return NextResponse.json(
+        { error: publishError.message, code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    // NOTE: Actual queue integration (QStash) will be handled by x-publish teammate
+    return NextResponse.json(
+      { post_id: id, status: newStatus, publishes },
+      { status: 202 },
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/posts/[id]/route.ts
+++ b/src/app/api/posts/[id]/route.ts
@@ -1,23 +1,169 @@
-// GET (detail) + PATCH (update) + DELETE (soft delete) — implemented in Directive ④
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { UpdatePostSchema } from "@/types/post";
+import type { PostWithAdaptations } from "@/types/post";
 
-export async function GET() {
-  return NextResponse.json(
-    { message: "Post detail — not yet implemented" },
-    { status: 501 },
-  );
+type RouteContext = { params: Promise<{ id: string }> };
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    const { data: post, error } = await supabase
+      .from("sns_posts")
+      .select("*")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (error || !post) {
+      return NextResponse.json(
+        { error: "Post not found", code: "NOT_FOUND" },
+        { status: 404 },
+      );
+    }
+
+    const { data: adaptations } = await supabase
+      .from("sns_post_adaptations")
+      .select("*")
+      .eq("post_id", id);
+
+    const result: PostWithAdaptations = {
+      ...post,
+      adaptations: adaptations ?? [],
+    };
+
+    return NextResponse.json(result);
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
 }
 
-export async function PATCH() {
-  return NextResponse.json(
-    { message: "Update post — not yet implemented" },
-    { status: 501 },
-  );
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // Check post exists and belongs to user
+    const { data: existing, error: fetchError } = await supabase
+      .from("sns_posts")
+      .select("status")
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .single();
+
+    if (fetchError || !existing) {
+      return NextResponse.json(
+        { error: "Post not found", code: "NOT_FOUND" },
+        { status: 404 },
+      );
+    }
+
+    // Only allow updates when status is draft or pending_approval
+    if (existing.status !== "draft" && existing.status !== "pending_approval") {
+      return NextResponse.json(
+        {
+          error: "Can only update posts in draft or pending_approval status",
+          code: "INVALID_STATUS",
+        },
+        { status: 409 },
+      );
+    }
+
+    const body = await request.json();
+    const parsed = UpdatePostSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: parsed.error.issues.map((i) => i.message).join("; "),
+          code: "VALIDATION_ERROR",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { data: updated, error: updateError } = await supabase
+      .from("sns_posts")
+      .update({ ...parsed.data, updated_at: new Date().toISOString() })
+      .eq("id", id)
+      .eq("user_id", user.id)
+      .select()
+      .single();
+
+    if (updateError) {
+      return NextResponse.json(
+        { error: updateError.message, code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json(updated);
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
 }
 
-export async function DELETE() {
-  return NextResponse.json(
-    { message: "Delete post — not yet implemented" },
-    { status: 501 },
-  );
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // RLS ensures user can only delete their own posts
+    const { error } = await supabase
+      .from("sns_posts")
+      .delete()
+      .eq("id", id)
+      .eq("user_id", user.id);
+
+    if (error) {
+      return NextResponse.json(
+        { error: "Post not found", code: "NOT_FOUND" },
+        { status: 404 },
+      );
+    }
+
+    return new NextResponse(null, { status: 204 });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,13 +1,136 @@
-// POST (create) + GET (list) — implemented in Directive ④
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { CreatePostSchema } from "@/types/post";
 
-export async function GET() {
-  return NextResponse.json({ message: "Posts API — not yet implemented" });
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    const body = await request.json();
+    const parsed = CreatePostSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: parsed.error.issues.map((i) => i.message).join("; "),
+          code: "VALIDATION_ERROR",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { platforms, ...postData } = parsed.data;
+
+    const { data: post, error } = await supabase
+      .from("sns_posts")
+      .insert({
+        user_id: user.id,
+        status: "draft",
+        ...postData,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json(
+        { error: error.message, code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    // Create adaptations for each target platform if specified
+    if (platforms && platforms.length > 0) {
+      const adaptations = platforms.map((platform) => ({
+        post_id: post.id,
+        platform,
+        content_adapted: postData.content_original,
+        constraints_applied: {},
+      }));
+
+      await supabase.from("sns_post_adaptations").insert(adaptations);
+    }
+
+    return NextResponse.json(post, { status: 201 });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
 }
 
-export async function POST() {
-  return NextResponse.json(
-    { message: "Create post — not yet implemented" },
-    { status: 501 },
-  );
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    const { searchParams } = request.nextUrl;
+    const status = searchParams.get("status");
+    const platform = searchParams.get("platform");
+    const limit = Math.min(
+      parseInt(searchParams.get("limit") || "20", 10),
+      100,
+    );
+    const offset = parseInt(searchParams.get("offset") || "0", 10);
+
+    let query = supabase
+      .from("sns_posts")
+      .select("*", { count: "exact" })
+      .eq("user_id", user.id)
+      .order("created_at", { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (status) {
+      query = query.eq("status", status);
+    }
+
+    // Filter by platform via sns_post_adaptations join
+    if (platform) {
+      const { data: adaptationPostIds } = await supabase
+        .from("sns_post_adaptations")
+        .select("post_id")
+        .eq("platform", platform);
+
+      if (adaptationPostIds && adaptationPostIds.length > 0) {
+        const postIds = adaptationPostIds.map((a) => a.post_id);
+        query = query.in("id", postIds);
+      } else {
+        return NextResponse.json({ data: [], count: 0 });
+      }
+    }
+
+    const { data: posts, error, count } = await query;
+
+    if (error) {
+      return NextResponse.json(
+        { error: error.message, code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ data: posts, count });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
 }

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,2 +1,8 @@
-// Supabase browser client — implemented in Directive ④
-export {};
+import { createBrowserClient } from "@supabase/ssr";
+
+export function createSupabaseBrowserClient() {
+  return createBrowserClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+  );
+}

--- a/src/types/post.ts
+++ b/src/types/post.ts
@@ -1,2 +1,91 @@
-// Post types + zod schemas — implemented in Directive ④
-export {};
+import { z } from "zod/v4";
+
+// Post status enum
+export const PostStatus = z.enum([
+  "draft",
+  "pending_approval",
+  "approved",
+  "scheduled",
+  "publishing",
+  "published",
+  "failed",
+]);
+export type PostStatus = z.infer<typeof PostStatus>;
+
+// Platform enum
+export const Platform = z.enum([
+  "x",
+  "instagram",
+  "tiktok",
+  "youtube",
+  "linkedin",
+]);
+export type Platform = z.infer<typeof Platform>;
+
+// Create post schema
+export const CreatePostSchema = z.object({
+  title: z.string().optional(),
+  content_original: z.string().min(1, "Content is required"),
+  scheduled_at: z.string().datetime().optional(),
+  tags: z.array(z.string()).optional(),
+  media_urls: z.array(z.string().url()).optional(),
+  platforms: z.array(Platform).optional(),
+});
+export type CreatePostInput = z.infer<typeof CreatePostSchema>;
+
+// Update post schema
+export const UpdatePostSchema = z.object({
+  title: z.string().optional(),
+  content_original: z.string().min(1).optional(),
+  scheduled_at: z.string().datetime().nullable().optional(),
+  tags: z.array(z.string()).optional(),
+  media_urls: z.array(z.string().url()).optional(),
+  status: PostStatus.optional(),
+});
+export type UpdatePostInput = z.infer<typeof UpdatePostSchema>;
+
+// Post type (DB row)
+export interface Post {
+  id: string;
+  user_id: string;
+  title: string | null;
+  content_original: string;
+  status: PostStatus;
+  scheduled_at: string | null;
+  tags: string[] | null;
+  media_urls: string[] | null;
+  created_at: string;
+  updated_at: string;
+  published_at: string | null;
+}
+
+// Post adaptation type
+export interface PostAdaptation {
+  id: string;
+  post_id: string;
+  platform: Platform;
+  content_adapted: string;
+  media_ids: string[] | null;
+  constraints_applied: Record<string, unknown>;
+  created_at: string;
+  updated_at: string;
+}
+
+// Post publish type
+export interface PostPublish {
+  id: string;
+  post_id: string;
+  platform: string;
+  status: "pending" | "publishing" | "published" | "failed";
+  platform_post_id: string | null;
+  platform_url: string | null;
+  error_message: string | null;
+  retry_count: number;
+  published_at: string | null;
+  created_at: string;
+}
+
+// Post with adaptations (for detail view)
+export interface PostWithAdaptations extends Post {
+  adaptations: PostAdaptation[];
+}


### PR DESCRIPTION
## Summary
- Implements Directive ④ — Posts CRUD API with full approval/publish workflow
- Zod v4 validation schemas for `CreatePost` and `UpdatePost` inputs
- Complete type definitions for `Post`, `PostAdaptation`, `PostPublish`
- Supabase browser client (`createSupabaseBrowserClient`)

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| POST | `/api/posts` | Create draft post (with optional platform adaptations) |
| GET | `/api/posts` | List posts with status/platform/pagination filters |
| GET | `/api/posts/[id]` | Post detail with adaptations |
| PATCH | `/api/posts/[id]` | Update post (draft/pending_approval only) |
| DELETE | `/api/posts/[id]` | Delete post |
| POST | `/api/posts/[id]/approve` | Approve post (pending_approval -> approved) |
| POST | `/api/posts/[id]/publish` | Initiate publish (creates sns_post_publishes records) |

## Error handling
- `400 VALIDATION_ERROR` — Zod validation failures
- `401 UNAUTHORIZED` — No Supabase auth session
- `404 NOT_FOUND` — Post not found or not owned by user
- `409 INVALID_STATUS` — Invalid state transition

## Test plan
- [ ] Verify `pnpm build` passes (confirmed locally)
- [ ] Test POST /api/posts with valid/invalid payloads
- [ ] Test status transition guards (PATCH only in draft/pending_approval)
- [ ] Test approve flow (only from pending_approval)
- [ ] Test publish flow (only from approved/scheduled)
- [ ] Verify RLS filtering by user_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)