### PR TITLE
feat(sns): Phase 2 UI screens (#10/#11/#12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,23 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@radix-ui/react-avatar": "^1.1.11",
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-slot": "^1.2.4",
     "@supabase/ssr": "^0.9.0",
     "@supabase/supabase-js": "^2.98.0",
     "@upstash/qstash": "^2.9.0",
     "@upstash/redis": "^1.36.3",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.577.0",
     "next": "16.1.6",
     "react": "19.2.3",
     "react-dom": "19.2.3",
+    "recharts": "^3.7.0",
+    "swr": "^2.4.1",
+    "tailwind-merge": "^3.5.0",
     "twitter-api-v2": "^1.29.0",
     "zod": "^4.3.6"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,18 @@ importers:
 
   .:
     dependencies:
+      '@radix-ui/react-avatar':
+        specifier: ^1.1.11
+        version: 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.4
+        version: 1.2.4(@types/react@19.2.14)(react@19.2.3)
       '@supabase/ssr':
         specifier: ^0.9.0
         version: 0.9.0(@supabase/supabase-js@2.98.0)
@@ -20,6 +32,15 @@ importers:
       '@upstash/redis':
         specifier: ^1.36.3
         version: 1.36.3
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.577.0
+        version: 0.577.0(react@19.2.3)
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.29.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -29,6 +50,15 @@ importers:
       react-dom:
         specifier: 19.2.3
         version: 19.2.3(react@19.2.3)
+      recharts:
+        specifier: ^3.7.0
+        version: 3.7.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1)
+      swr:
+        specifier: ^2.4.1
+        version: 2.4.1(react@19.2.3)
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
       twitter-api-v2:
         specifier: ^1.29.0
         version: 1.29.0
@@ -186,6 +216,21 @@ packages:
   '@eslint/plugin-kit@0.4.1':
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
@@ -449,8 +494,357 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
+  '@radix-ui/primitive@1.1.3':
+    resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-avatar@1.1.11':
+    resolution: {integrity: sha512-0Qk603AHGV28BOBO34p7IgD5m+V5Sg/YovfayABkoDDBM5d3NCx0Mp4gGrjzLGes1jV5eNOE1r3itqOR33VC6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.3':
+    resolution: {integrity: sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-is-hydrated@0.1.0':
+    resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@reduxjs/toolkit@2.11.2':
+    resolution: {integrity: sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@supabase/auth-js@2.98.0':
     resolution: {integrity: sha512-GBH361T0peHU91AQNzOlIrjUZw9TZbB9YDRiyFgk/3Kvr3/Z1NWUZ2athWTfHhwNNi8IrW00foyFxQD9IO/Trg==}
@@ -579,6 +973,33 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -601,6 +1022,9 @@ packages:
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -793,6 +1217,10 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
   aria-query@5.3.2:
     resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
     engines: {node: '>= 0.4'}
@@ -899,8 +1327,15 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -928,6 +1363,50 @@ packages:
 
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -961,6 +1440,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
@@ -972,9 +1454,16 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1025,6 +1514,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -1160,6 +1652,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1229,6 +1724,10 @@ packages:
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
+
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
 
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
@@ -1313,6 +1812,12 @@ packages:
     resolution: {integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==}
     engines: {node: '>= 4'}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.4:
+    resolution: {integrity: sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==}
+
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
@@ -1324,6 +1829,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -1581,6 +2090,11 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.577.0:
+    resolution: {integrity: sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
@@ -1767,9 +2281,67 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-redux@9.2.0:
+    resolution: {integrity: sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react@19.2.3:
     resolution: {integrity: sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==}
     engines: {node: '>=0.10.0'}
+
+  recharts@3.7.0:
+    resolution: {integrity: sha512-l2VCsy3XXeraxIID9fx23eCb6iCBsxUQDnE8tWm6DFdszVAO7WVY/ChAD9wVit01y6B2PMupYiMmQwhgPHc9Ew==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1778,6 +2350,9 @@ packages:
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -1930,12 +2505,23 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  swr@2.4.1:
+    resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
+    peerDependencies:
+      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
   tailwindcss@4.2.1:
     resolution: {integrity: sha512-/tBrSQ36vCleJkAOsy9kbNTgaxvGbyOamC30PRePTQe/o1MFwEKHQk4Cn7BNGaPtjp+PuUrByJehM1hgxfq4sw==}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -2013,6 +2599,34 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -2233,6 +2847,23 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -2411,7 +3042,327 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-avatar@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-context': 1.1.3(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-is-hydrated': 0.1.0(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.3(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-direction@1.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      aria-hidden: 1.2.6
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.2.14)(react@19.2.3)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-is-hydrated@0.1.0(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.3)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.3)
+      react: 19.2.3
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/rect@1.1.1': {}
+
+  '@reduxjs/toolkit@2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.4
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.3
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1)
+
   '@rtsao/scc@1.1.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@supabase/auth-js@2.98.0':
     dependencies:
@@ -2534,6 +3485,30 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2553,6 +3528,8 @@ snapshots:
   '@types/react@19.2.14':
     dependencies:
       csstype: 3.2.3
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -2737,6 +3714,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.2: {}
 
   array-buffer-byte-length@1.0.2:
@@ -2871,7 +3852,13 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   client-only@0.0.1: {}
+
+  clsx@2.1.1: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -2894,6 +3881,44 @@ snapshots:
   crypto-js@4.2.0: {}
 
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
 
   damerau-levenshtein@1.0.8: {}
 
@@ -2923,6 +3948,8 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
   deep-is@0.1.4: {}
 
   define-data-property@1.1.4:
@@ -2937,7 +3964,11 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  detect-node-es@1.1.0: {}
 
   doctrine@2.1.0:
     dependencies:
@@ -3059,6 +4090,8 @@ snapshots:
       is-date-object: 1.1.0
       is-symbol: 1.1.1
 
+  es-toolkit@1.45.1: {}
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -3110,7 +4143,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -3132,7 +4165,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.3(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.3(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.1(eslint@9.39.3(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.3(jiti@2.6.1)))(eslint@9.39.3(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -3272,6 +4305,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@5.0.4: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.1:
@@ -3348,6 +4383,8 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-nonce@1.0.1: {}
+
   get-proto@1.0.1:
     dependencies:
       dunder-proto: 1.0.1
@@ -3418,6 +4455,10 @@ snapshots:
 
   ignore@7.0.5: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.4: {}
+
   import-fresh@3.3.1:
     dependencies:
       parent-module: 1.0.1
@@ -3430,6 +4471,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -3665,6 +4708,10 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@0.577.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3847,7 +4894,69 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.3)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.3)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.3)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.3)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.3)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.3):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   react@19.2.3: {}
+
+  recharts@3.7.0(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react-is@16.13.1)(react@19.2.3)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.11.2(react-redux@9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1))(react@19.2.3)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.45.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
+      react-is: 16.13.1
+      react-redux: 9.2.0(@types/react@19.2.14)(react@19.2.3)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -3868,6 +4977,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -4083,9 +5194,19 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  swr@2.4.1(react@19.2.3):
+    dependencies:
+      dequal: 2.0.3
+      react: 19.2.3
+      use-sync-external-store: 1.6.0(react@19.2.3)
+
+  tailwind-merge@3.5.0: {}
+
   tailwindcss@4.2.1: {}
 
   tapable@2.3.0: {}
+
+  tiny-invariant@1.3.3: {}
 
   tinyglobby@0.2.15:
     dependencies:
@@ -4205,6 +5326,42 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.3):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.3
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sync-external-store@1.6.0(react@19.2.3):
+    dependencies:
+      react: 19.2.3
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
+packages:
+  - "."
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/src/app/(dashboard)/analytics/page.tsx
+++ b/src/app/(dashboard)/analytics/page.tsx
@@ -1,0 +1,414 @@
+"use client";
+
+import * as React from "react";
+import useSWR from "swr";
+import {
+  Bar,
+  BarChart,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { useOrg } from "@/components/tenant/org-context";
+import { apiFetch } from "@/lib/api/fetcher";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+type Range = "7d" | "30d" | "90d";
+
+type OverviewResponse = {
+  range_days: number;
+  kpis: {
+    reach: number;
+    engagement: number;
+    engagement_rate: number;
+    ctr: number;
+    followers_delta: number | null;
+  };
+  posts: { total: number; by_status: Record<string, number> };
+};
+
+type PlatformBreakdownResponse = {
+  data: Array<{
+    platform: string;
+    impressions: number;
+    engagement: number;
+    ctr: number;
+    sparkline: Array<{ date: string; impressions: number }>;
+  }>;
+};
+
+type ContentPerformanceResponse = {
+  data: Array<{
+    publish_id: string;
+    post_id: string;
+    platform: string;
+    published_at: string | null;
+    title: string | null;
+    content_preview: string;
+    tags: string[];
+    impressions: number;
+    engagement: number;
+    ctr: number;
+  }>;
+};
+
+type InsightsResponse = {
+  data: Array<{
+    title: string;
+    evidence: string;
+    next_action: string;
+    status: "planned" | "running" | "concluded";
+  }>;
+};
+
+export default function AnalyticsPage() {
+  const { activeOrg } = useOrg();
+  const orgId = activeOrg?.id;
+  const [range, setRange] = React.useState<Range>("7d");
+
+  const { data: overview, error: overviewError } = useSWR<OverviewResponse>(
+    orgId ? `/api/analytics/overview?range=${range}` : null,
+    (url: string) => apiFetch<OverviewResponse>(url, { orgId }),
+  );
+
+  const { data: platform } = useSWR<PlatformBreakdownResponse>(
+    orgId ? `/api/analytics/platform-breakdown?range=${range}` : null,
+    (url: string) => apiFetch<PlatformBreakdownResponse>(url, { orgId }),
+  );
+
+  const { data: performance } = useSWR<ContentPerformanceResponse>(
+    orgId ? `/api/analytics/content-performance?range=${range}` : null,
+    (url: string) => apiFetch<ContentPerformanceResponse>(url, { orgId }),
+  );
+
+  const { data: insights } = useSWR<InsightsResponse>(
+    orgId ? `/api/analytics/learning-insights?range=${range}` : null,
+    (url: string) => apiFetch<InsightsResponse>(url, { orgId }),
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Analytics</h1>
+          <p className="mt-1 text-sm text-zinc-500">
+            Engagement overview, platform breakdown, and learnings for the
+            active workspace.
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <RangeButton value="7d" current={range} onClick={setRange} />
+          <RangeButton value="30d" current={range} onClick={setRange} />
+          <RangeButton value="90d" current={range} onClick={setRange} />
+        </div>
+      </div>
+
+      {overviewError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {overviewError.message}
+        </div>
+      ) : null}
+
+      <EngagementOverview overview={overview ?? null} />
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <PlatformBreakdown breakdown={platform?.data ?? []} />
+        <LearningInsights insights={insights?.data ?? []} />
+      </div>
+
+      <ContentPerformance rows={performance?.data ?? []} />
+    </div>
+  );
+}
+
+function RangeButton({
+  value,
+  current,
+  onClick,
+}: {
+  value: Range;
+  current: Range;
+  onClick: (v: Range) => void;
+}) {
+  const active = value === current;
+  return (
+    <Button
+      variant={active ? "default" : "outline"}
+      onClick={() => onClick(value)}
+      className="h-9"
+    >
+      {value}
+    </Button>
+  );
+}
+
+function EngagementOverview({
+  overview,
+}: {
+  overview: OverviewResponse | null;
+}) {
+  const k = overview?.kpis;
+  return (
+    <div className="grid grid-cols-1 gap-4 md:grid-cols-4">
+      <KpiCard
+        label="Reach"
+        value={k ? formatInt(k.reach) : "—"}
+        hint="Impressions"
+      />
+      <KpiCard
+        label="Engagement"
+        value={k ? formatInt(k.engagement) : "—"}
+        hint="Likes+comments+shares+saves"
+      />
+      <KpiCard
+        label="Engagement rate"
+        value={k ? formatPct(k.engagement_rate) : "—"}
+        hint="Engagement / impressions"
+      />
+      <KpiCard
+        label="CTR"
+        value={k ? formatPct(k.ctr) : "—"}
+        hint="Clicks / impressions"
+      />
+    </div>
+  );
+}
+
+function KpiCard({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-2xl font-bold">{value}</div>
+        <div className="mt-1 text-xs text-zinc-500">{hint}</div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlatformBreakdown({
+  breakdown,
+}: {
+  breakdown: PlatformBreakdownResponse["data"];
+}) {
+  const chartData = breakdown.map((b) => ({
+    platform: b.platform,
+    impressions: b.impressions,
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Platform breakdown</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="h-44 w-full">
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={chartData}>
+              <XAxis dataKey="platform" tick={{ fontSize: 12 }} />
+              <YAxis tick={{ fontSize: 12 }} />
+              <Tooltip />
+              <Bar dataKey="impressions" fill="#18181b" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </div>
+
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Platform</TableHead>
+              <TableHead className="text-right">Impressions</TableHead>
+              <TableHead className="text-right">Engagement</TableHead>
+              <TableHead className="text-right">CTR</TableHead>
+              <TableHead className="text-right">Trend</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {breakdown.map((b) => (
+              <TableRow key={b.platform}>
+                <TableCell className="font-medium">{b.platform}</TableCell>
+                <TableCell className="text-right">
+                  {formatInt(b.impressions)}
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatInt(b.engagement)}
+                </TableCell>
+                <TableCell className="text-right">{formatPct(b.ctr)}</TableCell>
+                <TableCell className="text-right">
+                  <div className="ml-auto h-10 w-28">
+                    <ResponsiveContainer width="100%" height="100%">
+                      <LineChart data={b.sparkline}>
+                        <Line
+                          type="monotone"
+                          dataKey="impressions"
+                          stroke="#18181b"
+                          strokeWidth={2}
+                          dot={false}
+                        />
+                      </LineChart>
+                    </ResponsiveContainer>
+                  </div>
+                </TableCell>
+              </TableRow>
+            ))}
+            {breakdown.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-sm text-zinc-500">
+                  No analytics yet. Publish some posts to populate metrics.
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function ContentPerformance({
+  rows,
+}: {
+  rows: ContentPerformanceResponse["data"];
+}) {
+  const [sortKey, setSortKey] = React.useState<
+    "impressions" | "engagement" | "ctr"
+  >("impressions");
+
+  const sorted = React.useMemo(() => {
+    return [...rows].sort((a, b) => b[sortKey] - a[sortKey]);
+  }, [rows, sortKey]);
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between">
+        <CardTitle>Top posts</CardTitle>
+        <select
+          className="h-9 rounded-md border border-zinc-200 bg-white px-3 text-sm"
+          value={sortKey}
+          onChange={(e) => setSortKey(e.target.value as typeof sortKey)}
+        >
+          <option value="impressions">Impressions</option>
+          <option value="engagement">Engagement</option>
+          <option value="ctr">CTR</option>
+        </select>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Platform</TableHead>
+              <TableHead>Preview</TableHead>
+              <TableHead className="text-right">Impressions</TableHead>
+              <TableHead className="text-right">Engagement</TableHead>
+              <TableHead className="text-right">CTR</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sorted.map((r) => (
+              <TableRow key={r.publish_id}>
+                <TableCell className="font-medium">{r.platform}</TableCell>
+                <TableCell className="max-w-[640px]">
+                  <div className="truncate text-sm">
+                    {r.title ? (
+                      <span className="font-medium">{r.title} — </span>
+                    ) : null}
+                    {r.content_preview}
+                  </div>
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {r.tags.slice(0, 4).map((t) => (
+                      <Badge key={t} variant="secondary">
+                        {t}
+                      </Badge>
+                    ))}
+                  </div>
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatInt(r.impressions)}
+                </TableCell>
+                <TableCell className="text-right">
+                  {formatInt(r.engagement)}
+                </TableCell>
+                <TableCell className="text-right">{formatPct(r.ctr)}</TableCell>
+              </TableRow>
+            ))}
+            {sorted.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5} className="text-sm text-zinc-500">
+                  No published posts in this range.
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function LearningInsights({
+  insights,
+}: {
+  insights: InsightsResponse["data"];
+}) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Learning insights</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {insights.map((i) => (
+          <div key={i.title} className="rounded-md border border-zinc-200 p-3">
+            <div className="flex items-start justify-between gap-3">
+              <div className="text-sm font-medium">{i.title}</div>
+              <Badge variant="default" className="capitalize">
+                {i.status}
+              </Badge>
+            </div>
+            <div className="mt-1 text-sm text-zinc-600">{i.evidence}</div>
+            <div className="mt-2 text-sm">
+              <span className="font-medium">Next:</span> {i.next_action}
+            </div>
+          </div>
+        ))}
+        {insights.length === 0 ? (
+          <div className="text-sm text-zinc-500">
+            No insights yet. Once analytics data accumulates, suggestions appear
+            here.
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatInt(n: number) {
+  return new Intl.NumberFormat().format(n);
+}
+
+function formatPct(n: number) {
+  return `${(n * 100).toFixed(1)}%`;
+}

--- a/src/app/(dashboard)/generate/page.tsx
+++ b/src/app/(dashboard)/generate/page.tsx
@@ -1,0 +1,570 @@
+"use client";
+
+import * as React from "react";
+import useSWR from "swr";
+
+import { useOrg } from "@/components/tenant/org-context";
+import { apiFetch, apiPost } from "@/lib/api/fetcher";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import type { BrandVoiceSettings, Platform } from "@/types/ai";
+import type { Post } from "@/types/post";
+import type { CreatePostInput } from "@/types/post";
+
+type GenerateChunkEvent = {
+  variation_id: number;
+  platform: Platform;
+  content: string;
+  hashtags: string[];
+};
+
+type GenerateDoneEvent = {
+  variations: Array<{
+    variation_id: number;
+    adaptations: Record<string, { content: string; hashtags: string[] }>;
+  }>;
+};
+
+type WinningExample = { post_id: string; similarity: number; content: string };
+
+export default function GeneratePage() {
+  const { activeOrg } = useOrg();
+  const orgId = activeOrg?.id;
+
+  const [topic, setTopic] = React.useState("");
+  const [platforms, setPlatforms] = React.useState<Platform[]>(["x"]);
+  const [variationCount, setVariationCount] = React.useState(3);
+
+  const { data: brandVoiceResp } = useSWR<{
+    brand_voice: Partial<BrandVoiceSettings>;
+  }>(orgId ? `/api/orgs/${orgId}/brand-voice` : null, (url: string) =>
+    apiFetch<{ brand_voice: Partial<BrandVoiceSettings> }>(url),
+  );
+
+  const brandVoice = brandVoiceResp?.brand_voice ?? {};
+  const [tone, setTone] =
+    React.useState<BrandVoiceSettings["tone"]>("professional");
+  const [keywords, setKeywords] = React.useState("");
+  const [avoid, setAvoid] = React.useState("");
+  const [personality, setPersonality] = React.useState("");
+
+  React.useEffect(() => {
+    setTone((brandVoice.tone as BrandVoiceSettings["tone"]) ?? "professional");
+    setKeywords((brandVoice.keywords ?? []).join(", "));
+    setAvoid((brandVoice.avoid_words ?? []).join(", "));
+    setPersonality(brandVoice.personality ?? "");
+  }, [brandVoiceResp]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const primaryPlatform = platforms[0] ?? "x";
+  const { data: examplesResp } = useSWR<{ data: WinningExample[] }>(
+    orgId && topic.trim().length > 0
+      ? `/api/analytics/winning-posts?org_id=${encodeURIComponent(orgId)}&platform=${encodeURIComponent(primaryPlatform)}&topic=${encodeURIComponent(topic)}&count=3`
+      : null,
+    (url: string) => apiFetch<{ data: WinningExample[] }>(url, { orgId }),
+  );
+
+  const [isGenerating, setIsGenerating] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+  const [chunks, setChunks] = React.useState<
+    Record<number, Record<string, GenerateChunkEvent>>
+  >({});
+  const [done, setDone] = React.useState<GenerateDoneEvent | null>(null);
+
+  const [savedPostId, setSavedPostId] = React.useState<string | null>(null);
+  const [saving, setSaving] = React.useState(false);
+
+  async function generate() {
+    if (!orgId) return;
+    setIsGenerating(true);
+    setError(null);
+    setChunks({});
+    setDone(null);
+    setSavedPostId(null);
+
+    try {
+      const res = await fetch("/api/generate", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-Org-Id": orgId,
+        },
+        body: JSON.stringify({
+          topic,
+          platforms,
+          variation_count: variationCount,
+          brand_voice_override: {
+            tone,
+            keywords: splitCsv(keywords),
+            avoid_words: splitCsv(avoid),
+            personality,
+          },
+        }),
+      });
+
+      if (!res.ok || !res.body) {
+        const msg = await res.text();
+        throw new Error(msg || `Request failed: ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = "";
+
+      while (true) {
+        const { done: doneReading, value } = await reader.read();
+        if (doneReading) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        const events = parseSseBuffer(buffer);
+        buffer = events.rest;
+        for (const ev of events.events) {
+          if (ev.event === "chunk") {
+            const payload = ev.data as GenerateChunkEvent;
+            setChunks((prev) => {
+              const byVar = prev[payload.variation_id] ?? {};
+              return {
+                ...prev,
+                [payload.variation_id]: {
+                  ...byVar,
+                  [payload.platform]: payload,
+                },
+              };
+            });
+          }
+          if (ev.event === "done") {
+            setDone(ev.data as GenerateDoneEvent);
+          }
+          if (ev.event === "error") {
+            const msg = getErrorMessage(ev.data) ?? "Generation failed";
+            setError(msg);
+          }
+        }
+      }
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Generation failed");
+    } finally {
+      setIsGenerating(false);
+    }
+  }
+
+  async function saveDraft(payload: { content: string; tags: string[] }) {
+    if (!orgId) return;
+    setSaving(true);
+    try {
+      const postBody: CreatePostInput = {
+        title: `AI: ${topic}`.slice(0, 120),
+        content_original: payload.content,
+        org_id: orgId,
+        tags: Array.from(new Set(["ai_generated", ...payload.tags])),
+        platforms: platforms as CreatePostInput["platforms"],
+      };
+      const post = await apiPost<Post, CreatePostInput>("/api/posts", postBody);
+      setSavedPostId(post.id);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function requestApproval() {
+    if (!savedPostId) return;
+    try {
+      await apiFetch(`/api/posts/${savedPostId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "pending_approval" }),
+      });
+      window.location.href = "/posts";
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to request approval");
+    }
+  }
+
+  const variations = buildVariationsFromChunks(chunks, done);
+
+  return (
+    <div className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_1fr]">
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold">AI Studio</h1>
+          <p className="mt-1 text-sm text-zinc-500">
+            Generate platform-specific drafts, then save to your approval flow.
+          </p>
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Generate</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="topic">Topic</Label>
+              <Input
+                id="topic"
+                value={topic}
+                onChange={(e) => setTopic(e.target.value)}
+                placeholder="e.g. AI×運用の勝ちパターン"
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <Label>Platforms</Label>
+              <div className="flex flex-wrap gap-2">
+                {(
+                  [
+                    "x",
+                    "instagram",
+                    "tiktok",
+                    "youtube",
+                    "linkedin",
+                  ] as Platform[]
+                ).map((p) => (
+                  <button
+                    key={p}
+                    type="button"
+                    onClick={() => togglePlatform(p, platforms, setPlatforms)}
+                    className={`rounded-md border px-3 py-1.5 text-sm ${
+                      platforms.includes(p)
+                        ? "border-zinc-900 bg-zinc-900 text-white"
+                        : "border-zinc-200 bg-white text-zinc-800 hover:bg-zinc-50"
+                    }`}
+                  >
+                    {p}
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+              <div className="space-y-1.5">
+                <Label htmlFor="tone">Tone</Label>
+                <select
+                  id="tone"
+                  className="h-9 w-full rounded-md border border-zinc-200 bg-white px-3 text-sm"
+                  value={tone}
+                  onChange={(e) =>
+                    setTone(e.target.value as BrandVoiceSettings["tone"])
+                  }
+                >
+                  <option value="formal">formal</option>
+                  <option value="casual">casual</option>
+                  <option value="professional">professional</option>
+                  <option value="friendly">friendly</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label htmlFor="count">Variations</Label>
+                <select
+                  id="count"
+                  className="h-9 w-full rounded-md border border-zinc-200 bg-white px-3 text-sm"
+                  value={variationCount}
+                  onChange={(e) =>
+                    setVariationCount(parseInt(e.target.value, 10))
+                  }
+                >
+                  <option value={1}>1</option>
+                  <option value={2}>2</option>
+                  <option value={3}>3</option>
+                  <option value={4}>4</option>
+                  <option value={5}>5</option>
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>Workspace role</Label>
+                <div className="h-9 rounded-md border border-zinc-200 bg-white px-3 text-sm flex items-center capitalize">
+                  {activeOrg?.role ?? "—"}
+                </div>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <Label htmlFor="keywords">Brand keywords (comma separated)</Label>
+              <Input
+                id="keywords"
+                value={keywords}
+                onChange={(e) => setKeywords(e.target.value)}
+                placeholder="e.g. 実装, 検証, 静寂"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="avoid">Avoid words (comma separated)</Label>
+              <Input
+                id="avoid"
+                value={avoid}
+                onChange={(e) => setAvoid(e.target.value)}
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="personality">Personality</Label>
+              <Input
+                id="personality"
+                value={personality}
+                onChange={(e) => setPersonality(e.target.value)}
+              />
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button
+                onClick={generate}
+                disabled={isGenerating || !topic.trim()}
+              >
+                {isGenerating ? "Generating…" : "Generate"}
+              </Button>
+              <Button
+                variant="outline"
+                onClick={generate}
+                disabled={isGenerating || !topic.trim()}
+              >
+                Regenerate
+              </Button>
+            </div>
+
+            {error ? (
+              <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                {error}
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Reference: winning posts</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            {(examplesResp?.data ?? []).map((ex) => (
+              <div
+                key={ex.post_id}
+                className="rounded-md border border-zinc-200 p-3"
+              >
+                <div className="flex items-center justify-between text-xs text-zinc-500">
+                  <span className="font-mono">{ex.post_id.slice(0, 8)}…</span>
+                  <span>sim {(ex.similarity * 100).toFixed(1)}%</span>
+                </div>
+                <div className="mt-2 text-sm text-zinc-800 whitespace-pre-wrap">
+                  {ex.content}
+                </div>
+              </div>
+            ))}
+            {(examplesResp?.data ?? []).length === 0 ? (
+              <div className="text-sm text-zinc-500">
+                Type a topic to fetch similar high-engagement examples.
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Preview</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {variations.length === 0 ? (
+              <div className="text-sm text-zinc-500">
+                Generate to see streaming results here.
+              </div>
+            ) : (
+              variations.map((v) => (
+                <div key={v.variation_id} className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div className="text-sm font-medium">
+                      Variation {v.variation_id}
+                    </div>
+                    <Badge variant="secondary">
+                      {Object.keys(v.adaptations).length} platforms
+                    </Badge>
+                  </div>
+                  <div className="grid grid-cols-1 gap-3">
+                    {Object.entries(v.adaptations).map(([p, a]) => (
+                      <div
+                        key={p}
+                        className="rounded-md border border-zinc-200 p-3"
+                      >
+                        <div className="flex items-center justify-between">
+                          <div className="text-xs font-medium uppercase text-zinc-500">
+                            {p}
+                          </div>
+                          <Button
+                            size="sm"
+                            onClick={() =>
+                              saveDraft({
+                                content: a.content,
+                                tags: a.hashtags,
+                              })
+                            }
+                            disabled={saving}
+                          >
+                            {saving ? "Saving…" : "Save draft"}
+                          </Button>
+                        </div>
+                        <Textarea className="mt-2" value={a.content} readOnly />
+                        {a.hashtags.length > 0 ? (
+                          <div className="mt-2 flex flex-wrap gap-1">
+                            {a.hashtags.slice(0, 8).map((h) => (
+                              <Badge key={h} variant="default">
+                                {h}
+                              </Badge>
+                            ))}
+                          </div>
+                        ) : null}
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ))
+            )}
+
+            {savedPostId ? (
+              <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-800">
+                Draft saved: <span className="font-mono">{savedPostId}</span>
+                <div className="mt-2 flex gap-2">
+                  <Button onClick={() => (window.location.href = "/posts")}>
+                    Go to posts
+                  </Button>
+                  <Button variant="outline" onClick={requestApproval}>
+                    Request approval
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <HistoryLog orgId={orgId ?? null} />
+      </div>
+    </div>
+  );
+}
+
+function HistoryLog({ orgId }: { orgId: string | null }) {
+  const { data } = useSWR<{ data: Post[] }>(
+    orgId ? `/api/posts?org_id=${encodeURIComponent(orgId)}&limit=30` : null,
+    (url: string) =>
+      apiFetch<{ data: Post[] }>(url, { orgId: orgId ?? undefined }),
+  );
+
+  const rows = (data?.data ?? [])
+    .filter((p) => (p.tags ?? []).includes("ai_generated"))
+    .slice(0, 10);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>History</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {rows.map((p) => (
+          <div key={p.id} className="rounded-md border border-zinc-200 p-3">
+            <div className="flex items-center justify-between">
+              <div className="truncate text-sm font-medium">
+                {p.title ?? "AI draft"}
+              </div>
+              <Badge variant="secondary">{p.status}</Badge>
+            </div>
+            <div className="mt-1 truncate text-sm text-zinc-600">
+              {p.content_original}
+            </div>
+          </div>
+        ))}
+        {rows.length === 0 ? (
+          <div className="text-sm text-zinc-500">
+            No AI drafts yet. Save a generated variation to see it here.
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function togglePlatform(
+  p: Platform,
+  current: Platform[],
+  set: React.Dispatch<React.SetStateAction<Platform[]>>,
+) {
+  set((prev) => {
+    const has = prev.includes(p);
+    if (has) {
+      const next = prev.filter((x) => x !== p);
+      return next.length > 0 ? next : prev;
+    }
+    return [...prev, p];
+  });
+}
+
+function splitCsv(input: string): string[] {
+  return input
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function buildVariationsFromChunks(
+  chunks: Record<number, Record<string, GenerateChunkEvent>>,
+  done: GenerateDoneEvent | null,
+) {
+  if (done?.variations?.length) {
+    return done.variations.map((v) => ({
+      variation_id: v.variation_id,
+      adaptations: Object.fromEntries(
+        Object.entries(v.adaptations).map(([k, a]) => [k, a]),
+      ) as Record<string, { content: string; hashtags: string[] }>,
+    }));
+  }
+
+  const ids = Object.keys(chunks)
+    .map((n) => parseInt(n, 10))
+    .sort((a, b) => a - b);
+  return ids.map((id) => ({
+    variation_id: id,
+    adaptations: Object.fromEntries(
+      Object.entries(chunks[id] ?? {}).map(([p, ev]) => [
+        p,
+        { content: ev.content, hashtags: ev.hashtags },
+      ]),
+    ),
+  }));
+}
+
+function parseSseBuffer(buffer: string): {
+  events: Array<{ event: string; data: unknown }>;
+  rest: string;
+} {
+  const events: Array<{ event: string; data: unknown }> = [];
+  const parts = buffer.split("\n\n");
+  const rest = parts.pop() ?? "";
+
+  for (const part of parts) {
+    const lines = part.split("\n").filter(Boolean);
+    let event = "message";
+    let dataStr = "";
+    for (const line of lines) {
+      if (line.startsWith("event:")) {
+        event = line.slice("event:".length).trim();
+      } else if (line.startsWith("data:")) {
+        dataStr += line.slice("data:".length).trim();
+      }
+    }
+    if (!dataStr) continue;
+    try {
+      events.push({ event, data: JSON.parse(dataStr) });
+    } catch {
+      events.push({ event, data: dataStr });
+    }
+  }
+
+  return { events, rest };
+}
+
+function getErrorMessage(data: unknown): string | null {
+  if (!data || typeof data !== "object") return null;
+  if (!("error" in data)) return null;
+  const err = (data as { error?: unknown }).error;
+  return typeof err === "string" ? err : null;
+}

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,0 +1,14 @@
+import type { Metadata } from "next";
+
+import { DashboardShell } from "@/components/dashboard/DashboardShell";
+
+export const metadata: Metadata = {
+  title: "SNS Auto-Post",
+  description: "Multi-tenant SNS posting operations",
+};
+
+export default function DashboardLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return <DashboardShell>{children}</DashboardShell>;
+}

--- a/src/app/(dashboard)/page.tsx
+++ b/src/app/(dashboard)/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
-export default function LegacyDashboardPage() {
+export default function DashboardIndex() {
   redirect("/posts");
 }

--- a/src/app/(dashboard)/posts/page.tsx
+++ b/src/app/(dashboard)/posts/page.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import * as React from "react";
+import useSWR from "swr";
+
+import { useOrg } from "@/components/tenant/org-context";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { apiFetch } from "@/lib/api/fetcher";
+import type { Post } from "@/types/post";
+
+type PostsResponse = { data: Post[]; count: number };
+
+export default function PostsPage() {
+  const { activeOrg } = useOrg();
+  const orgId = activeOrg?.id;
+
+  const [status, setStatus] = React.useState<string>("all");
+
+  const qs = new URLSearchParams();
+  if (status !== "all") qs.set("status", status);
+  if (orgId) qs.set("org_id", orgId);
+  qs.set("limit", "50");
+
+  const { data, error, isLoading } = useSWR<PostsResponse>(
+    orgId ? `/api/posts?${qs.toString()}` : null,
+    (url: string) => apiFetch<PostsResponse>(url, { orgId }),
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Posts</h1>
+        <p className="mt-1 text-sm text-zinc-500">
+          Drafts, approvals, and publishing status per workspace.
+        </p>
+      </div>
+
+      <Card>
+        <CardHeader className="flex-row items-center justify-between">
+          <CardTitle>Recent</CardTitle>
+          <select
+            className="h-9 rounded-md border border-zinc-200 bg-white px-3 text-sm"
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+          >
+            <option value="all">All</option>
+            <option value="draft">Draft</option>
+            <option value="pending_approval">Pending approval</option>
+            <option value="approved">Approved</option>
+            <option value="scheduled">Scheduled</option>
+            <option value="publishing">Publishing</option>
+            <option value="published">Published</option>
+            <option value="failed">Failed</option>
+          </select>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <div className="text-sm text-zinc-500">Loading…</div>
+          ) : error ? (
+            <div className="text-sm text-red-600">{error.message}</div>
+          ) : (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Title</TableHead>
+                  <TableHead>Created</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(data?.data ?? []).map((post) => (
+                  <TableRow key={post.id}>
+                    <TableCell>
+                      <Badge variant={statusToBadge(post.status)}>
+                        {post.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="max-w-[520px] truncate">
+                      {post.title ?? post.content_original.slice(0, 80)}
+                    </TableCell>
+                    <TableCell className="text-zinc-500">
+                      {new Date(post.created_at).toLocaleString()}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                {(data?.data ?? []).length === 0 ? (
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-sm text-zinc-500">
+                      No posts found.
+                    </TableCell>
+                  </TableRow>
+                ) : null}
+              </TableBody>
+            </Table>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function statusToBadge(status: string) {
+  if (status === "published" || status === "approved")
+    return "success" as const;
+  if (status === "failed") return "destructive" as const;
+  if (status === "pending_approval") return "warning" as const;
+  return "default" as const;
+}

--- a/src/app/(dashboard)/settings/organization/page.tsx
+++ b/src/app/(dashboard)/settings/organization/page.tsx
@@ -1,0 +1,647 @@
+"use client";
+
+import * as React from "react";
+import useSWR, { mutate } from "swr";
+
+import { useOrg } from "@/components/tenant/org-context";
+import { apiFetch, apiPost } from "@/lib/api/fetcher";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import type { Organization, OrgRole } from "@/types/organization";
+import type { BrandVoiceSettings } from "@/types/ai";
+
+type MemberRow = {
+  id: string;
+  role: OrgRole;
+  joined_at: string;
+  invited_by: string | null;
+  user: {
+    id: string;
+    email: string;
+    name: string | null;
+    avatar_url: string | null;
+  };
+};
+
+type UsageResponse = {
+  plan: string;
+  limits: {
+    members: number;
+    postsPerMonth: number;
+    generationsPerMonth: number;
+  };
+  usage: {
+    members: number;
+    postsThisMonth: number;
+    publishesThisMonth: number;
+  };
+};
+
+export default function OrganizationSettingsPage() {
+  const { activeOrg } = useOrg();
+  const orgId = activeOrg?.id;
+
+  const { data: org, error: orgError } = useSWR<Organization>(
+    orgId ? `/api/orgs/${orgId}` : null,
+    (url: string) => apiFetch<Organization>(url),
+  );
+
+  const { data: membersResp } = useSWR<{ data: MemberRow[] }>(
+    orgId ? `/api/orgs/${orgId}/members` : null,
+    (url: string) => apiFetch<{ data: MemberRow[] }>(url),
+  );
+
+  const { data: usage } = useSWR<UsageResponse>(
+    orgId ? `/api/orgs/${orgId}/usage` : null,
+    (url: string) => apiFetch<UsageResponse>(url),
+  );
+
+  const { data: brandVoiceResp } = useSWR<{
+    brand_voice: Partial<BrandVoiceSettings>;
+  }>(orgId ? `/api/orgs/${orgId}/brand-voice` : null, (url: string) =>
+    apiFetch<{ brand_voice: Partial<BrandVoiceSettings> }>(url),
+  );
+
+  const members = membersResp?.data ?? [];
+  const canManage =
+    (activeOrg?.role ?? "viewer") === "owner" ||
+    (activeOrg?.role ?? "viewer") === "admin";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold">Organization settings</h1>
+        <p className="mt-1 text-sm text-zinc-500">
+          Manage workspace profile, members, usage, and brand voice.
+        </p>
+      </div>
+
+      {orgError ? (
+        <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+          {orgError.message}
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <OrgProfileCard
+          org={org ?? null}
+          orgId={orgId ?? null}
+          canManage={canManage}
+        />
+        <PlanUsageCard usage={usage ?? null} />
+      </div>
+
+      <MembersCard
+        orgId={orgId ?? null}
+        members={members}
+        canManage={canManage}
+      />
+      <BrandVoiceCard
+        orgId={orgId ?? null}
+        canManage={canManage}
+        brandVoice={brandVoiceResp?.brand_voice ?? {}}
+      />
+    </div>
+  );
+}
+
+function OrgProfileCard({
+  org,
+  orgId,
+  canManage,
+}: {
+  org: Organization | null;
+  orgId: string | null;
+  canManage: boolean;
+}) {
+  const [name, setName] = React.useState("");
+  const [logoUrl, setLogoUrl] = React.useState("");
+  const [saving, setSaving] = React.useState(false);
+  const [err, setErr] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setName(org?.name ?? "");
+    setLogoUrl(org?.logo_url ?? "");
+  }, [org?.name, org?.logo_url]);
+
+  async function save() {
+    if (!orgId) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      await apiFetch<Organization>(`/api/orgs/${orgId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, logo_url: logoUrl || undefined }),
+      });
+      await mutate(`/api/orgs/${orgId}`);
+      await mutate("/api/orgs");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between">
+        <CardTitle>Workspace profile</CardTitle>
+        {canManage ? (
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button variant="outline">Edit</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Edit workspace</DialogTitle>
+                <DialogDescription>
+                  Owners/admins can update workspace name and logo URL.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="mt-4 space-y-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="org-name">Name</Label>
+                  <Input
+                    id="org-name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    placeholder="Acme Inc."
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="org-logo">Logo URL</Label>
+                  <Input
+                    id="org-logo"
+                    value={logoUrl}
+                    onChange={(e) => setLogoUrl(e.target.value)}
+                    placeholder="https://…"
+                  />
+                </div>
+                {err ? <div className="text-sm text-red-600">{err}</div> : null}
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  onClick={() => setErr(null)}
+                >
+                  Cancel
+                </Button>
+                <Button type="button" onClick={save} disabled={saving}>
+                  {saving ? "Saving…" : "Save"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        ) : (
+          <Badge variant="secondary">Read-only</Badge>
+        )}
+      </CardHeader>
+      <CardContent>
+        {!org ? (
+          <div className="text-sm text-zinc-500">Loading…</div>
+        ) : (
+          <div className="flex items-center gap-4">
+            <Avatar className="h-12 w-12">
+              <AvatarImage src={org.logo_url ?? undefined} alt={org.name} />
+              <AvatarFallback>
+                {org.name.slice(0, 2).toUpperCase()}
+              </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+              <div className="truncate text-sm font-semibold">{org.name}</div>
+              <div className="truncate text-sm text-zinc-500">
+                slug: <span className="font-mono">{org.slug}</span>
+              </div>
+              <div className="mt-1">
+                <Badge variant="default" className="capitalize">
+                  plan: {org.plan}
+                </Badge>
+              </div>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function PlanUsageCard({ usage }: { usage: UsageResponse | null }) {
+  const members = usage?.usage.members ?? 0;
+  const posts = usage?.usage.postsThisMonth ?? 0;
+  const publishes = usage?.usage.publishesThisMonth ?? 0;
+
+  const memberLimit = usage?.limits.members ?? 0;
+  const postsLimit = usage?.limits.postsPerMonth ?? 0;
+  const genLimit = usage?.limits.generationsPerMonth ?? 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Plan & usage</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!usage ? (
+          <div className="text-sm text-zinc-500">Loading…</div>
+        ) : (
+          <>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-zinc-500">Plan</span>
+              <span className="font-medium capitalize">{usage.plan}</span>
+            </div>
+            <UsageBar label="Members" value={members} limit={memberLimit} />
+            <UsageBar
+              label="Posts (this month)"
+              value={posts}
+              limit={postsLimit}
+            />
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-zinc-500">Publishes (this month)</span>
+              <span className="font-medium">{publishes}</span>
+            </div>
+            <div className="flex items-center justify-between text-sm">
+              <span className="text-zinc-500">AI generations (limit)</span>
+              <span className="font-medium">{genLimit}</span>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function UsageBar({
+  label,
+  value,
+  limit,
+}: {
+  label: string;
+  value: number;
+  limit: number;
+}) {
+  const pct = limit > 0 ? Math.min(100, Math.round((value / limit) * 100)) : 0;
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between text-sm">
+        <span className="text-zinc-500">{label}</span>
+        <span className="font-medium">
+          {value} / {limit}
+        </span>
+      </div>
+      <div className="h-2 w-full rounded-full bg-zinc-100">
+        <div
+          className="h-2 rounded-full bg-zinc-900"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+function MembersCard({
+  orgId,
+  members,
+  canManage,
+}: {
+  orgId: string | null;
+  members: MemberRow[];
+  canManage: boolean;
+}) {
+  const [inviteEmail, setInviteEmail] = React.useState("");
+  const [inviteRole, setInviteRole] = React.useState<OrgRole>("editor");
+  const [inviting, setInviting] = React.useState(false);
+  const [inviteErr, setInviteErr] = React.useState<string | null>(null);
+
+  async function invite() {
+    if (!orgId) return;
+    setInviting(true);
+    setInviteErr(null);
+    try {
+      await apiPost(`/api/orgs/${orgId}/invite`, {
+        email: inviteEmail,
+        role: inviteRole === "owner" ? "admin" : inviteRole,
+      });
+      setInviteEmail("");
+      setInviteRole("editor");
+    } catch (e) {
+      setInviteErr(e instanceof Error ? e.message : "Invite failed");
+    } finally {
+      setInviting(false);
+    }
+  }
+
+  async function updateRole(userId: string, role: OrgRole) {
+    if (!orgId) return;
+    await apiFetch(`/api/orgs/${orgId}/members`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId, role }),
+    });
+    await mutate(`/api/orgs/${orgId}/members`);
+    await mutate("/api/orgs");
+  }
+
+  async function removeMember(userId: string) {
+    if (!orgId) return;
+    await apiFetch(`/api/orgs/${orgId}/members`, {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ userId }),
+    });
+    await mutate(`/api/orgs/${orgId}/members`);
+    await mutate("/api/orgs");
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between">
+        <CardTitle>Members</CardTitle>
+        {canManage ? (
+          <Dialog>
+            <DialogTrigger asChild>
+              <Button>Invite</Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>Invite member</DialogTitle>
+                <DialogDescription>
+                  Invite by email, assign a role, and manage access.
+                </DialogDescription>
+              </DialogHeader>
+              <div className="mt-4 space-y-3">
+                <div className="space-y-1.5">
+                  <Label htmlFor="invite-email">Email</Label>
+                  <Input
+                    id="invite-email"
+                    value={inviteEmail}
+                    onChange={(e) => setInviteEmail(e.target.value)}
+                    placeholder="member@example.com"
+                  />
+                </div>
+                <div className="space-y-1.5">
+                  <Label htmlFor="invite-role">Role</Label>
+                  <select
+                    id="invite-role"
+                    className="h-9 w-full rounded-md border border-zinc-200 bg-white px-3 text-sm"
+                    value={inviteRole}
+                    onChange={(e) => setInviteRole(e.target.value as OrgRole)}
+                  >
+                    <option value="admin">Admin</option>
+                    <option value="editor">Editor</option>
+                    <option value="viewer">Viewer</option>
+                  </select>
+                </div>
+                {inviteErr ? (
+                  <div className="text-sm text-red-600">{inviteErr}</div>
+                ) : null}
+              </div>
+              <DialogFooter>
+                <Button
+                  variant="secondary"
+                  type="button"
+                  onClick={() => setInviteErr(null)}
+                >
+                  Cancel
+                </Button>
+                <Button type="button" onClick={invite} disabled={inviting}>
+                  {inviting ? "Inviting…" : "Send invite"}
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        ) : (
+          <Badge variant="secondary">Read-only</Badge>
+        )}
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>User</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead>Joined</TableHead>
+              <TableHead />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {members.map((m) => (
+              <TableRow key={m.id}>
+                <TableCell>
+                  <div className="flex items-center gap-3">
+                    <Avatar>
+                      <AvatarImage
+                        src={m.user.avatar_url ?? undefined}
+                        alt={m.user.email}
+                      />
+                      <AvatarFallback>
+                        {m.user.email.slice(0, 2).toUpperCase()}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="min-w-0">
+                      <div className="truncate text-sm font-medium">
+                        {m.user.name || m.user.email}
+                      </div>
+                      <div className="truncate text-xs text-zinc-500">
+                        {m.user.email}
+                      </div>
+                    </div>
+                  </div>
+                </TableCell>
+                <TableCell>
+                  {canManage ? (
+                    <select
+                      className="h-9 rounded-md border border-zinc-200 bg-white px-3 text-sm capitalize"
+                      value={m.role}
+                      onChange={(e) =>
+                        updateRole(m.user.id, e.target.value as OrgRole)
+                      }
+                      disabled={m.role === "owner" && !canManage}
+                    >
+                      <option value="owner">Owner</option>
+                      <option value="admin">Admin</option>
+                      <option value="editor">Editor</option>
+                      <option value="viewer">Viewer</option>
+                    </select>
+                  ) : (
+                    <Badge variant="secondary" className="capitalize">
+                      {m.role}
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-zinc-500">
+                  {new Date(m.joined_at).toLocaleDateString()}
+                </TableCell>
+                <TableCell className="text-right">
+                  {canManage ? (
+                    <Button
+                      variant="ghost"
+                      className="text-red-600 hover:text-red-700"
+                      onClick={() => removeMember(m.user.id)}
+                    >
+                      Remove
+                    </Button>
+                  ) : null}
+                </TableCell>
+              </TableRow>
+            ))}
+            {members.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4} className="text-sm text-zinc-500">
+                  No members found.
+                </TableCell>
+              </TableRow>
+            ) : null}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}
+
+function BrandVoiceCard({
+  orgId,
+  canManage,
+  brandVoice,
+}: {
+  orgId: string | null;
+  canManage: boolean;
+  brandVoice: Partial<BrandVoiceSettings>;
+}) {
+  const [tone, setTone] = React.useState(brandVoice.tone ?? "professional");
+  const [keywords, setKeywords] = React.useState(
+    (brandVoice.keywords ?? []).join(", "),
+  );
+  const [avoid, setAvoid] = React.useState(
+    (brandVoice.avoid_words ?? []).join(", "),
+  );
+  const [personality, setPersonality] = React.useState(
+    brandVoice.personality ?? "",
+  );
+  const [saving, setSaving] = React.useState(false);
+  const [err, setErr] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    setTone(brandVoice.tone ?? "professional");
+    setKeywords((brandVoice.keywords ?? []).join(", "));
+    setAvoid((brandVoice.avoid_words ?? []).join(", "));
+    setPersonality(brandVoice.personality ?? "");
+  }, [brandVoice]);
+
+  async function save() {
+    if (!orgId) return;
+    setSaving(true);
+    setErr(null);
+    try {
+      await apiFetch(`/api/orgs/${orgId}/brand-voice`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          tone,
+          keywords: splitCsv(keywords),
+          avoid_words: splitCsv(avoid),
+          personality,
+        }),
+      });
+      await mutate(`/api/orgs/${orgId}/brand-voice`);
+      await mutate(`/api/orgs/${orgId}`);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Update failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between">
+        <CardTitle>Brand voice</CardTitle>
+        {canManage ? (
+          <Button onClick={save} disabled={saving}>
+            {saving ? "Saving…" : "Save"}
+          </Button>
+        ) : (
+          <Badge variant="secondary">Read-only</Badge>
+        )}
+      </CardHeader>
+      <CardContent className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div className="space-y-1.5">
+          <Label htmlFor="bv-tone">Tone</Label>
+          <select
+            id="bv-tone"
+            className="h-9 w-full rounded-md border border-zinc-200 bg-white px-3 text-sm"
+            value={tone}
+            onChange={(e) =>
+              setTone(e.target.value as BrandVoiceSettings["tone"])
+            }
+            disabled={!canManage}
+          >
+            <option value="formal">formal</option>
+            <option value="casual">casual</option>
+            <option value="professional">professional</option>
+            <option value="friendly">friendly</option>
+          </select>
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="bv-personality">Personality</Label>
+          <Input
+            id="bv-personality"
+            value={personality}
+            onChange={(e) => setPersonality(e.target.value)}
+            placeholder="e.g. calm, direct, helpful"
+            disabled={!canManage}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="bv-keywords">Keywords (comma separated)</Label>
+          <Input
+            id="bv-keywords"
+            value={keywords}
+            onChange={(e) => setKeywords(e.target.value)}
+            disabled={!canManage}
+          />
+        </div>
+        <div className="space-y-1.5">
+          <Label htmlFor="bv-avoid">Avoid words (comma separated)</Label>
+          <Input
+            id="bv-avoid"
+            value={avoid}
+            onChange={(e) => setAvoid(e.target.value)}
+            disabled={!canManage}
+          />
+        </div>
+        {err ? (
+          <div className="md:col-span-2 text-sm text-red-600">{err}</div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}
+
+function splitCsv(input: string): string[] {
+  return input
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}

--- a/src/app/(dashboard)/settings/page.tsx
+++ b/src/app/(dashboard)/settings/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation";
 
-export default function LegacySettingsPage() {
+export default function SettingsIndex() {
   redirect("/settings/organization");
 }

--- a/src/app/api/analytics/content-performance/route.ts
+++ b/src/app/api/analytics/content-performance/route.ts
@@ -1,0 +1,102 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgScope } from "@/lib/api/org-scope";
+
+function parseRange(range: string | null): number {
+  if (range === "90d") return 90;
+  if (range === "30d") return 30;
+  return 7;
+}
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireOrgScope(request);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const days = parseRange(request.nextUrl.searchParams.get("range"));
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data } = await ctx.supabase
+    .from("sns_post_publishes")
+    .select(
+      `
+      id,
+      platform,
+      published_at,
+      post:sns_posts!inner (
+        id,
+        title,
+        content_original,
+        tags,
+        org_id
+      ),
+      analytics:sns_post_analytics (
+        impressions,
+        clicks,
+        likes,
+        comments,
+        shares,
+        saves
+      )
+    `,
+    )
+    .eq("post.org_id", ctx.orgId)
+    .eq("status", "published")
+    .gte("published_at", since);
+
+  const rows = (data ?? []) as unknown as Array<{
+    id: string;
+    platform: string;
+    published_at: string | null;
+    post:
+      | {
+          id: string;
+          title: string | null;
+          content_original: string;
+          tags: string[] | null;
+          org_id: string;
+        }
+      | Array<{
+          id: string;
+          title: string | null;
+          content_original: string;
+          tags: string[] | null;
+          org_id: string;
+        }>;
+    analytics: Array<{
+      impressions: number | null;
+      clicks: number | null;
+      likes: number | null;
+      comments: number | null;
+      shares: number | null;
+      saves: number | null;
+    }> | null;
+  }>;
+
+  const enriched = rows
+    .map((r) => {
+      const post = Array.isArray(r.post) ? r.post[0] : r.post;
+      const a = r.analytics?.[0];
+      const impressions = a?.impressions ?? 0;
+      const clicks = a?.clicks ?? 0;
+      const engagement =
+        (a?.likes ?? 0) +
+        (a?.comments ?? 0) +
+        (a?.shares ?? 0) +
+        (a?.saves ?? 0);
+      return {
+        publish_id: r.id,
+        post_id: post.id,
+        platform: r.platform,
+        published_at: r.published_at,
+        title: post.title,
+        content_preview: post.content_original.slice(0, 140),
+        tags: post.tags ?? [],
+        impressions,
+        engagement,
+        ctr: impressions > 0 ? clicks / impressions : 0,
+      };
+    })
+    .sort((a, b) => b.impressions - a.impressions)
+    .slice(0, 10);
+
+  return NextResponse.json({ range_days: days, data: enriched });
+}

--- a/src/app/api/analytics/learning-insights/route.ts
+++ b/src/app/api/analytics/learning-insights/route.ts
@@ -1,0 +1,120 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgScope } from "@/lib/api/org-scope";
+
+function parseRange(range: string | null): number {
+  if (range === "90d") return 90;
+  if (range === "30d") return 30;
+  return 7;
+}
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireOrgScope(request);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const days = parseRange(request.nextUrl.searchParams.get("range"));
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data } = await ctx.supabase
+    .from("sns_post_publishes")
+    .select(
+      `
+      id,
+      platform,
+      published_at,
+      post:sns_posts!inner ( id, tags, org_id ),
+      analytics:sns_post_analytics ( impressions, likes, comments, shares, saves )
+    `,
+    )
+    .eq("post.org_id", ctx.orgId)
+    .eq("status", "published")
+    .gte("published_at", since);
+
+  const rows = (data ?? []) as unknown as Array<{
+    platform: string;
+    published_at: string | null;
+    post:
+      | { id: string; tags: string[] | null; org_id: string }
+      | Array<{ id: string; tags: string[] | null; org_id: string }>;
+    analytics: Array<{
+      impressions: number | null;
+      likes: number | null;
+      comments: number | null;
+      shares: number | null;
+      saves: number | null;
+    }> | null;
+  }>;
+
+  const tagCounts = new Map<string, number>();
+  const platformImpressions = new Map<string, number>();
+  const hourCounts = new Map<number, { impressions: number; n: number }>();
+
+  for (const r of rows) {
+    const post = Array.isArray(r.post) ? r.post[0] : r.post;
+    const a = r.analytics?.[0];
+    if (!a) continue;
+    const impressions = a.impressions ?? 0;
+    platformImpressions.set(
+      r.platform,
+      (platformImpressions.get(r.platform) ?? 0) + impressions,
+    );
+    for (const t of post.tags ?? []) {
+      tagCounts.set(t, (tagCounts.get(t) ?? 0) + 1);
+    }
+    if (r.published_at) {
+      const h = new Date(r.published_at).getHours();
+      const prev = hourCounts.get(h) ?? { impressions: 0, n: 0 };
+      hourCounts.set(h, {
+        impressions: prev.impressions + impressions,
+        n: prev.n + 1,
+      });
+    }
+  }
+
+  const topTag = Array.from(tagCounts.entries()).sort((a, b) => b[1] - a[1])[0];
+  const topPlatform = Array.from(platformImpressions.entries()).sort(
+    (a, b) => b[1] - a[1],
+  )[0];
+  const bestHour = Array.from(hourCounts.entries())
+    .map(([h, v]) => ({ h, avg: v.n > 0 ? v.impressions / v.n : 0 }))
+    .sort((a, b) => b.avg - a.avg)[0];
+
+  const insights = [
+    {
+      title: topTag
+        ? `Winning tag pattern: “${topTag[0]}”`
+        : "Add a consistent tag taxonomy",
+      evidence: topTag
+        ? `Most frequent tag in the last ${days} days: ${topTag[0]} (${topTag[1]} posts).`
+        : "Tags are sparse — consistent topic/format/hook tags unlock better analytics and reuse.",
+      next_action: topTag
+        ? "Create 2 new drafts reusing this tag + a different hook angle."
+        : "Standardize tags: topic / format / hook / CTA. Start with 3 options each.",
+      status: "planned" as const,
+    },
+    {
+      title: topPlatform
+        ? `Platform focus: ${topPlatform[0]}`
+        : "Compare platforms with enough volume",
+      evidence: topPlatform
+        ? `Highest impressions share in last ${days} days: ${topPlatform[0]} (${topPlatform[1]} impressions).`
+        : "Not enough published analytics yet to pick a leading platform.",
+      next_action: topPlatform
+        ? `Generate 5 variations for ${topPlatform[0]} using AI Studio and push to approval.`
+        : "Publish at least 5 posts per platform to stabilize the signal.",
+      status: "planned" as const,
+    },
+    {
+      title: bestHour
+        ? `Experiment: post time @ ${bestHour.h}:00`
+        : "Experiment: post time",
+      evidence: bestHour
+        ? `Best observed average impressions at ${bestHour.h}:00 (based on published posts in range).`
+        : "Time-of-day signal not yet stable. Start a controlled A/B time test.",
+      next_action:
+        "Run A/B test: same format + different time windows for 7 days.",
+      status: "planned" as const,
+    },
+  ];
+
+  return NextResponse.json({ range_days: days, data: insights });
+}

--- a/src/app/api/analytics/overview/route.ts
+++ b/src/app/api/analytics/overview/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgScope } from "@/lib/api/org-scope";
+
+function parseRange(range: string | null): number {
+  if (range === "90d") return 90;
+  if (range === "30d") return 30;
+  return 7;
+}
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireOrgScope(request);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const days = parseRange(request.nextUrl.searchParams.get("range"));
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  const [postsRes, publishesRes] = await Promise.all([
+    ctx.supabase
+      .from("sns_posts")
+      .select("id, status, created_at", { count: "exact" })
+      .eq("org_id", ctx.orgId)
+      .gte("created_at", since),
+    ctx.supabase
+      .from("sns_post_publishes")
+      .select(
+        `
+        id,
+        platform,
+        published_at,
+        post:sns_posts!inner ( org_id ),
+        analytics:sns_post_analytics (
+          impressions,
+          clicks,
+          likes,
+          comments,
+          shares,
+          saves,
+          video_views
+        )
+      `,
+      )
+      .eq("post.org_id", ctx.orgId)
+      .eq("status", "published")
+      .gte("published_at", since),
+  ]);
+
+  const posts = postsRes.data ?? [];
+  const statusCounts = posts.reduce<Record<string, number>>((acc, p) => {
+    acc[p.status] = (acc[p.status] || 0) + 1;
+    return acc;
+  }, {});
+
+  const rows = (publishesRes.data ?? []) as Array<{
+    analytics: Array<{
+      impressions: number | null;
+      clicks: number | null;
+      likes: number | null;
+      comments: number | null;
+      shares: number | null;
+      saves: number | null;
+    }> | null;
+  }>;
+  let impressions = 0;
+  let clicks = 0;
+  let engagement = 0;
+
+  for (const row of rows) {
+    const a = row.analytics?.[0];
+    if (!a) continue;
+    impressions += a.impressions ?? 0;
+    clicks += a.clicks ?? 0;
+    engagement +=
+      (a.likes ?? 0) + (a.comments ?? 0) + (a.shares ?? 0) + (a.saves ?? 0);
+  }
+
+  const er = impressions > 0 ? engagement / impressions : 0;
+  const ctr = impressions > 0 ? clicks / impressions : 0;
+
+  return NextResponse.json({
+    range_days: days,
+    kpis: {
+      reach: impressions,
+      engagement,
+      engagement_rate: er,
+      ctr,
+      followers_delta: null,
+    },
+    posts: {
+      total: posts.length,
+      by_status: statusCounts,
+    },
+  });
+}

--- a/src/app/api/analytics/platform-breakdown/route.ts
+++ b/src/app/api/analytics/platform-breakdown/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgScope } from "@/lib/api/org-scope";
+
+function parseRange(range: string | null): number {
+  if (range === "90d") return 90;
+  if (range === "30d") return 30;
+  return 7;
+}
+
+type AnalyticsRow = {
+  impressions: number | null;
+  clicks: number | null;
+  likes: number | null;
+  comments: number | null;
+  shares: number | null;
+  saves: number | null;
+  video_views: number | null;
+};
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireOrgScope(request);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const days = parseRange(request.nextUrl.searchParams.get("range"));
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  const { data } = await ctx.supabase
+    .from("sns_post_publishes")
+    .select(
+      `
+      id,
+      platform,
+      published_at,
+      post:sns_posts!inner ( org_id ),
+      analytics:sns_post_analytics (
+        impressions,
+        clicks,
+        likes,
+        comments,
+        shares,
+        saves,
+        video_views
+      )
+    `,
+    )
+    .eq("post.org_id", ctx.orgId)
+    .eq("status", "published")
+    .gte("published_at", since);
+
+  const rows = (data ?? []) as Array<{
+    platform: string;
+    published_at: string | null;
+    analytics: AnalyticsRow[] | null;
+  }>;
+
+  const byPlatform = new Map<
+    string,
+    {
+      impressions: number;
+      clicks: number;
+      engagement: number;
+      byDay: Map<string, number>;
+    }
+  >();
+
+  for (const row of rows) {
+    const platform = row.platform;
+    const a = row.analytics?.[0];
+    if (!a) continue;
+
+    const impressions = a.impressions ?? 0;
+    const clicks = a.clicks ?? 0;
+    const engagement =
+      (a.likes ?? 0) + (a.comments ?? 0) + (a.shares ?? 0) + (a.saves ?? 0);
+
+    const dayKey = row.published_at
+      ? new Date(row.published_at).toISOString().slice(0, 10)
+      : "unknown";
+
+    const bucket = byPlatform.get(platform) ?? {
+      impressions: 0,
+      clicks: 0,
+      engagement: 0,
+      byDay: new Map<string, number>(),
+    };
+
+    bucket.impressions += impressions;
+    bucket.clicks += clicks;
+    bucket.engagement += engagement;
+    if (dayKey !== "unknown") {
+      bucket.byDay.set(dayKey, (bucket.byDay.get(dayKey) ?? 0) + impressions);
+    }
+
+    byPlatform.set(platform, bucket);
+  }
+
+  const breakdown = Array.from(byPlatform.entries())
+    .map(([platform, b]) => ({
+      platform,
+      impressions: b.impressions,
+      engagement: b.engagement,
+      ctr: b.impressions > 0 ? b.clicks / b.impressions : 0,
+      sparkline: Array.from(b.byDay.entries())
+        .sort(([a], [b2]) => a.localeCompare(b2))
+        .map(([date, impressions]) => ({ date, impressions })),
+    }))
+    .sort((a, b) => b.impressions - a.impressions);
+
+  return NextResponse.json({ range_days: days, data: breakdown });
+}

--- a/src/app/api/analytics/winning-posts/route.ts
+++ b/src/app/api/analytics/winning-posts/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireOrgScope } from "@/lib/api/org-scope";
+import { findWinningExamples } from "@/lib/ai/embedding-pipeline";
+
+export async function GET(request: NextRequest) {
+  const ctx = await requireOrgScope(request);
+  if (ctx instanceof NextResponse) return ctx;
+
+  const topic = request.nextUrl.searchParams.get("topic") || "";
+  const platform = request.nextUrl.searchParams.get("platform") || "x";
+  const count = Math.min(
+    Math.max(parseInt(request.nextUrl.searchParams.get("count") || "3", 10), 1),
+    10,
+  );
+
+  if (!topic) {
+    return NextResponse.json(
+      { error: "topic is required", code: "VALIDATION_ERROR" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const examples = await findWinningExamples(
+      topic,
+      ctx.orgId,
+      platform,
+      count,
+    );
+    return NextResponse.json({ data: examples });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to fetch examples";
+    return NextResponse.json(
+      { error: message, code: "ANALYTICS_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -1,0 +1,245 @@
+import { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { z } from "zod/v4";
+import { createClient } from "@supabase/supabase-js";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { PROMPT_TEMPLATES, buildPrompt } from "@/lib/ai/prompt-templates";
+import { callLiteLLM } from "@/lib/ai/litellm-client";
+import { findWinningExamples } from "@/lib/ai/embedding-pipeline";
+import type { BrandVoiceSettings, Platform } from "@/types/ai";
+
+const GenerateStreamSchema = z.object({
+  topic: z.string().min(1),
+  platforms: z
+    .array(z.enum(["x", "instagram", "tiktok", "youtube", "linkedin"]))
+    .min(1),
+  variation_count: z.number().int().min(1).max(5).optional().default(3),
+  org_id: z.string().uuid().optional(),
+  brand_voice_override: z
+    .object({
+      tone: z.enum(["formal", "casual", "professional", "friendly"]).optional(),
+      keywords: z.array(z.string()).optional(),
+      avoid_words: z.array(z.string()).optional(),
+      personality: z.string().optional(),
+      example_posts: z.array(z.string()).optional(),
+    })
+    .optional(),
+});
+
+function getServiceClient() {
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!,
+  );
+}
+
+function sseEvent(event: string, data: unknown) {
+  return `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+}
+
+export async function POST(request: NextRequest) {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session) {
+    return NextResponse.json(
+      { error: "Unauthorized", code: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+
+  const body = await request.json().catch(() => null);
+  const parsed = GenerateStreamSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "Invalid request", code: "VALIDATION_ERROR" },
+      { status: 400 },
+    );
+  }
+
+  const orgId = request.headers.get("X-Org-Id") || parsed.data.org_id;
+  if (!orgId) {
+    return NextResponse.json(
+      { error: "org_id required", code: "MISSING_ORG_ID" },
+      { status: 400 },
+    );
+  }
+
+  // Verify org membership
+  const { data: membership } = await supabase
+    .from("sns_org_members")
+    .select("role")
+    .eq("org_id", orgId)
+    .eq("user_id", session.user.id)
+    .single();
+
+  if (!membership) {
+    return NextResponse.json(
+      { error: "Not a member of this organization", code: "FORBIDDEN" },
+      { status: 403 },
+    );
+  }
+
+  if (membership.role === "viewer") {
+    return NextResponse.json(
+      { error: "Viewers cannot generate content", code: "FORBIDDEN" },
+      { status: 403 },
+    );
+  }
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    start: async (controller) => {
+      try {
+        const service = getServiceClient();
+
+        const { data: org } = await service
+          .from("sns_organizations")
+          .select("brand_voice_settings")
+          .eq("id", orgId)
+          .single();
+
+        const baseBrandVoice: BrandVoiceSettings =
+          (org?.brand_voice_settings as BrandVoiceSettings) || {
+            tone: "professional",
+            keywords: [],
+            avoid_words: [],
+            personality: "",
+            example_posts: [],
+          };
+
+        const mergedBrandVoice: BrandVoiceSettings = {
+          ...baseBrandVoice,
+          ...(parsed.data.brand_voice_override || {}),
+        };
+
+        const brandVoiceStr = `Tone: ${mergedBrandVoice.tone}. Keywords: ${mergedBrandVoice.keywords.join(", ")}. Personality: ${mergedBrandVoice.personality}. Avoid: ${mergedBrandVoice.avoid_words.join(", ")}`;
+
+        controller.enqueue(
+          encoder.encode(
+            sseEvent("start", {
+              topic: parsed.data.topic,
+              platforms: parsed.data.platforms,
+              variation_count: parsed.data.variation_count,
+            }),
+          ),
+        );
+
+        const variations: Array<{
+          variation_id: number;
+          adaptations: Record<
+            string,
+            {
+              content: string;
+              hashtags: string[];
+              metadata?: Record<string, unknown>;
+            }
+          >;
+        }> = [];
+
+        for (let v = 0; v < parsed.data.variation_count; v++) {
+          const adaptations: Record<
+            string,
+            { content: string; hashtags: string[] }
+          > = {};
+
+          for (const platform of parsed.data.platforms as Platform[]) {
+            controller.enqueue(
+              encoder.encode(
+                sseEvent("status", {
+                  phase: "generating",
+                  variation_id: v + 1,
+                  platform,
+                }),
+              ),
+            );
+
+            const examples = await findWinningExamples(
+              parsed.data.topic,
+              orgId,
+              platform,
+              3,
+            );
+            const examplesStr =
+              examples.length > 0
+                ? examples
+                    .map((e, i) => `Example ${i + 1}: ${e.content}`)
+                    .join("\n")
+                : "No previous examples available.";
+
+            const template = PROMPT_TEMPLATES[platform];
+            const messages = buildPrompt(template, {
+              topic: parsed.data.topic,
+              brandVoice: brandVoiceStr,
+              examples: examplesStr,
+            });
+
+            messages.push({
+              role: "user",
+              content: `Generate variation ${v + 1} of ${parsed.data.variation_count}. Each variation should have a different angle or hook. Return JSON: { "content": "...", "hashtags": ["..."] }`,
+            });
+
+            const response = await callLiteLLM({
+              messages,
+              temperature: 0.8 + v * 0.05,
+            });
+
+            const responseText = response.choices?.[0]?.message?.content || "";
+
+            let parsedOut: { content: string; hashtags: string[] };
+            try {
+              const jsonMatch = responseText.match(/\{[\s\S]*\}/);
+              parsedOut = jsonMatch
+                ? (JSON.parse(jsonMatch[0]) as {
+                    content: string;
+                    hashtags: string[];
+                  })
+                : { content: responseText, hashtags: [] };
+            } catch {
+              parsedOut = { content: responseText, hashtags: [] };
+            }
+
+            adaptations[platform] = parsedOut;
+
+            controller.enqueue(
+              encoder.encode(
+                sseEvent("chunk", {
+                  variation_id: v + 1,
+                  platform,
+                  ...parsedOut,
+                }),
+              ),
+            );
+          }
+
+          const variation = { variation_id: v + 1, adaptations };
+          variations.push(variation);
+          controller.enqueue(
+            encoder.encode(sseEvent("variation_done", { variation_id: v + 1 })),
+          );
+        }
+
+        controller.enqueue(encoder.encode(sseEvent("done", { variations })));
+        controller.close();
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Generation failed";
+        controller.enqueue(
+          encoder.encode(sseEvent("error", { error: message })),
+        );
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream; charset=utf-8",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+    },
+  });
+}

--- a/src/app/api/orgs/[orgId]/members/route.ts
+++ b/src/app/api/orgs/[orgId]/members/route.ts
@@ -69,6 +69,134 @@ export async function GET(_request: NextRequest, context: RouteContext) {
   }
 }
 
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const { orgId } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // Verify the requesting user is owner or admin
+    const { data: membership, error: membershipError } = await supabase
+      .from("sns_org_members")
+      .select("role")
+      .eq("org_id", orgId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (membershipError || !membership) {
+      return NextResponse.json(
+        { error: "Not a member of this organization", code: "FORBIDDEN" },
+        { status: 403 },
+      );
+    }
+
+    if (membership.role !== "owner" && membership.role !== "admin") {
+      return NextResponse.json(
+        {
+          error: "Only owners and admins can change roles",
+          code: "FORBIDDEN",
+        },
+        { status: 403 },
+      );
+    }
+
+    const body = (await request.json()) as { userId?: string; role?: string };
+    const userId = body.userId;
+    const nextRole = body.role;
+    const allowed = new Set(["owner", "admin", "editor", "viewer"]);
+
+    if (!userId || !nextRole || !allowed.has(nextRole)) {
+      return NextResponse.json(
+        {
+          error: "userId and valid role are required",
+          code: "VALIDATION_ERROR",
+        },
+        { status: 400 },
+      );
+    }
+
+    // Only owners can assign owner role
+    if (nextRole === "owner" && membership.role !== "owner") {
+      return NextResponse.json(
+        { error: "Only owners can assign owner role", code: "FORBIDDEN" },
+        { status: 403 },
+      );
+    }
+
+    // Prevent removing the last owner
+    if (nextRole !== "owner") {
+      const { data: targetMember } = await supabase
+        .from("sns_org_members")
+        .select("role")
+        .eq("org_id", orgId)
+        .eq("user_id", userId)
+        .single();
+
+      if (targetMember?.role === "owner") {
+        const { count } = await supabase
+          .from("sns_org_members")
+          .select("*", { count: "exact", head: true })
+          .eq("org_id", orgId)
+          .eq("role", "owner");
+
+        if (count !== null && count <= 1) {
+          return NextResponse.json(
+            {
+              error: "Cannot change the last owner role",
+              code: "LAST_OWNER",
+            },
+            { status: 409 },
+          );
+        }
+      }
+    }
+
+    const { data: updated, error } = await supabase
+      .from("sns_org_members")
+      .update({ role: nextRole })
+      .eq("org_id", orgId)
+      .eq("user_id", userId)
+      .select(
+        `
+        id,
+        role,
+        joined_at,
+        invited_by,
+        user:sns_users (
+          id,
+          email,
+          name,
+          avatar_url
+        )
+      `,
+      )
+      .single();
+
+    if (error || !updated) {
+      return NextResponse.json(
+        { error: error?.message || "Update failed", code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    return NextResponse.json({ data: updated });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
+}
+
 export async function DELETE(request: NextRequest, context: RouteContext) {
   try {
     const { orgId } = await context.params;

--- a/src/app/api/orgs/[orgId]/route.ts
+++ b/src/app/api/orgs/[orgId]/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { UpdateOrgSchema } from "@/types/organization";
+
+type RouteContext = { params: Promise<{ orgId: string }> };
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const { orgId } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // Verify membership
+    const { data: membership } = await supabase
+      .from("sns_org_members")
+      .select("role")
+      .eq("org_id", orgId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (!membership) {
+      return NextResponse.json(
+        { error: "Not a member of this organization", code: "FORBIDDEN" },
+        { status: 403 },
+      );
+    }
+
+    const { data: org, error } = await supabase
+      .from("sns_organizations")
+      .select("*")
+      .eq("id", orgId)
+      .single();
+
+    if (error || !org) {
+      return NextResponse.json(
+        { error: "Organization not found", code: "NOT_FOUND" },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(org);
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
+}
+
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const { orgId } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // Verify membership + permissions
+    const { data: membership } = await supabase
+      .from("sns_org_members")
+      .select("role")
+      .eq("org_id", orgId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (!membership) {
+      return NextResponse.json(
+        { error: "Not a member of this organization", code: "FORBIDDEN" },
+        { status: 403 },
+      );
+    }
+
+    if (membership.role !== "owner" && membership.role !== "admin") {
+      return NextResponse.json(
+        {
+          error: "Only owners and admins can update organization settings",
+          code: "FORBIDDEN",
+        },
+        { status: 403 },
+      );
+    }
+
+    const body = await request.json();
+    const parsed = UpdateOrgSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        {
+          error: parsed.error.issues.map((i) => i.message).join("; "),
+          code: "VALIDATION_ERROR",
+        },
+        { status: 400 },
+      );
+    }
+
+    const { error } = await supabase
+      .from("sns_organizations")
+      .update({
+        ...parsed.data,
+        updated_at: new Date().toISOString(),
+      })
+      .eq("id", orgId);
+
+    if (error) {
+      return NextResponse.json(
+        { error: error.message, code: "DB_ERROR" },
+        { status: 500 },
+      );
+    }
+
+    const { data: org } = await supabase
+      .from("sns_organizations")
+      .select("*")
+      .eq("id", orgId)
+      .single();
+
+    return NextResponse.json(org);
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/orgs/[orgId]/usage/route.ts
+++ b/src/app/api/orgs/[orgId]/usage/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+type RouteContext = { params: Promise<{ orgId: string }> };
+
+const PLAN_LIMITS: Record<
+  string,
+  { members: number; postsPerMonth: number; generationsPerMonth: number }
+> = {
+  free: { members: 3, postsPerMonth: 30, generationsPerMonth: 50 },
+  starter: { members: 10, postsPerMonth: 200, generationsPerMonth: 500 },
+  pro: { members: 50, postsPerMonth: 2000, generationsPerMonth: 5000 },
+  enterprise: {
+    members: 500,
+    postsPerMonth: 20000,
+    generationsPerMonth: 50000,
+  },
+};
+
+export async function GET(_request: NextRequest, context: RouteContext) {
+  try {
+    const { orgId } = await context.params;
+    const supabase = await createSupabaseServerClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.json(
+        { error: "Unauthorized", code: "UNAUTHORIZED" },
+        { status: 401 },
+      );
+    }
+
+    // Verify membership
+    const { data: membership } = await supabase
+      .from("sns_org_members")
+      .select("role")
+      .eq("org_id", orgId)
+      .eq("user_id", user.id)
+      .single();
+
+    if (!membership) {
+      return NextResponse.json(
+        { error: "Not a member of this organization", code: "FORBIDDEN" },
+        { status: 403 },
+      );
+    }
+
+    const { data: org } = await supabase
+      .from("sns_organizations")
+      .select("plan")
+      .eq("id", orgId)
+      .single();
+
+    const plan = org?.plan ?? "free";
+    const limits = PLAN_LIMITS[plan] ?? PLAN_LIMITS.free;
+
+    const startOfMonth = new Date();
+    startOfMonth.setUTCDate(1);
+    startOfMonth.setUTCHours(0, 0, 0, 0);
+    const startIso = startOfMonth.toISOString();
+
+    const [
+      { count: memberCount },
+      { count: postsMonth },
+      { count: publishes },
+    ] = await Promise.all([
+      supabase
+        .from("sns_org_members")
+        .select("*", { count: "exact", head: true })
+        .eq("org_id", orgId),
+      supabase
+        .from("sns_posts")
+        .select("*", { count: "exact", head: true })
+        .eq("org_id", orgId)
+        .gte("created_at", startIso),
+      supabase
+        .from("sns_post_publishes")
+        .select(
+          `
+            id,
+            post:sns_posts!inner ( org_id )
+          `,
+          { count: "exact", head: true },
+        )
+        .eq("post.org_id", orgId)
+        .gte("created_at", startIso),
+    ]);
+
+    return NextResponse.json({
+      plan,
+      limits,
+      usage: {
+        members: memberCount ?? 0,
+        postsThisMonth: postsMonth ?? 0,
+        publishesThisMonth: publishes ?? 0,
+      },
+    });
+  } catch {
+    return NextResponse.json(
+      { error: "Internal server error", code: "INTERNAL_ERROR" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/webhooks/publish/route.ts
+++ b/src/app/api/webhooks/publish/route.ts
@@ -145,9 +145,8 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Supabase client type depends on generated DB types
 async function updatePublishStatus(
-  supabase: any,
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>,
   publishId: string,
   status: string,
   errorMessage: string | null,

--- a/src/app/dashboard/posts/page.tsx
+++ b/src/app/dashboard/posts/page.tsx
@@ -1,9 +1,5 @@
-// Posts list — implemented by Cursor (Directive ⑤)
-export default function PostsPage() {
-  return (
-    <div className="p-8">
-      <h1 className="text-2xl font-bold">Posts</h1>
-      <p className="text-gray-500 mt-2">Coming soon — implemented by Cursor</p>
-    </div>
-  );
+import { redirect } from "next/navigation";
+
+export default function LegacyPostsPage() {
+  redirect("/posts");
 }

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { BarChart3, PenSquare, Settings, Sparkles } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { OrgProvider } from "@/components/tenant/org-context";
+import { WorkspaceSwitcher } from "@/components/tenant/WorkspaceSwitcher";
+
+const navItems = [
+  { href: "/posts", label: "Posts", icon: PenSquare },
+  { href: "/generate", label: "AI Studio", icon: Sparkles },
+  { href: "/analytics", label: "Analytics", icon: BarChart3 },
+  { href: "/settings/organization", label: "Settings", icon: Settings },
+] as const;
+
+export function DashboardShell({ children }: { children: React.ReactNode }) {
+  return (
+    <OrgProvider>
+      <div className="min-h-screen bg-zinc-50">
+        <header className="sticky top-0 z-40 border-b border-zinc-200 bg-white">
+          <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+            <div className="flex items-center gap-3">
+              <Link href="/posts" className="text-sm font-semibold">
+                SNS Auto-Post
+              </Link>
+              <div className="hidden sm:block">
+                <WorkspaceSwitcher />
+              </div>
+            </div>
+            <div className="sm:hidden">
+              <WorkspaceSwitcher />
+            </div>
+          </div>
+        </header>
+
+        <div className="mx-auto grid max-w-6xl grid-cols-1 gap-6 px-4 py-6 md:grid-cols-[220px_1fr]">
+          <SidebarNav />
+          <main className="min-w-0">{children}</main>
+        </div>
+      </div>
+    </OrgProvider>
+  );
+}
+
+function SidebarNav() {
+  const pathname = usePathname();
+  return (
+    <nav className="flex flex-row gap-2 overflow-auto md:flex-col md:gap-1">
+      {navItems.map((item) => {
+        const active =
+          pathname === item.href || pathname?.startsWith(item.href);
+        const Icon = item.icon;
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={cn(
+              "flex items-center gap-2 rounded-md px-3 py-2 text-sm text-zinc-700 hover:bg-white hover:text-zinc-900",
+              active && "bg-white font-medium text-zinc-900 shadow-sm",
+            )}
+          >
+            <Icon className="h-4 w-4" />
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/tenant/WorkspaceSwitcher.tsx
+++ b/src/components/tenant/WorkspaceSwitcher.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import * as React from "react";
+import { ChevronsUpDown, Plus } from "lucide-react";
+
+import { useOrg } from "./org-context";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+function initials(name: string) {
+  const parts = name.trim().split(/\s+/).slice(0, 2);
+  return parts.map((p) => p[0]?.toUpperCase()).join("");
+}
+
+export function WorkspaceSwitcher() {
+  const { orgs, activeOrg, setActiveOrgId, isLoading } = useOrg();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="outline"
+          className="h-10 justify-between gap-3 px-3"
+          disabled={isLoading}
+        >
+          <span className="flex min-w-0 items-center gap-2">
+            <Avatar className="h-7 w-7">
+              <AvatarImage
+                src={activeOrg?.logo_url ?? undefined}
+                alt={activeOrg?.name ?? "Organization"}
+              />
+              <AvatarFallback>
+                {activeOrg?.name ? initials(activeOrg.name) : "—"}
+              </AvatarFallback>
+            </Avatar>
+            <span className="min-w-0 text-left">
+              <span className="block truncate text-sm font-medium">
+                {activeOrg?.name ?? "No workspace"}
+              </span>
+              {activeOrg?.role ? (
+                <span className="block truncate text-xs text-zinc-500">
+                  {activeOrg.role}
+                </span>
+              ) : null}
+            </span>
+          </span>
+          <ChevronsUpDown className="h-4 w-4 text-zinc-500" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72">
+        {orgs.length === 0 ? (
+          <DropdownMenuItem disabled>No organizations found</DropdownMenuItem>
+        ) : (
+          orgs.map((org) => (
+            <DropdownMenuItem
+              key={org.id}
+              onSelect={() => setActiveOrgId(org.id)}
+              className="flex items-center gap-2"
+            >
+              <Avatar className="h-7 w-7">
+                <AvatarImage src={org.logo_url ?? undefined} alt={org.name} />
+                <AvatarFallback>{initials(org.name)}</AvatarFallback>
+              </Avatar>
+              <span className="min-w-0 flex-1 truncate">{org.name}</span>
+              <Badge variant="secondary" className="capitalize">
+                {org.role}
+              </Badge>
+            </DropdownMenuItem>
+          ))
+        )}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem
+          onSelect={() => {
+            window.location.href = "/settings/organization";
+          }}
+          className="gap-2"
+        >
+          <Plus className="h-4 w-4" />
+          Manage workspaces
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/tenant/org-context.tsx
+++ b/src/components/tenant/org-context.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import * as React from "react";
+import useSWR from "swr";
+
+import { apiFetch } from "@/lib/api/fetcher";
+import type { Organization, OrgRole } from "@/types/organization";
+
+export type OrgSummary = Organization & {
+  role: OrgRole;
+  joined_at: string;
+};
+
+type OrgContextValue = {
+  orgs: OrgSummary[];
+  activeOrg: OrgSummary | null;
+  setActiveOrgId: (orgId: string) => void;
+  isLoading: boolean;
+  error: string | null;
+};
+
+const OrgContext = React.createContext<OrgContextValue | null>(null);
+
+const ACTIVE_ORG_STORAGE_KEY = "sns_auto_post.active_org_id";
+
+function getStoredOrgId(): string | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage.getItem(ACTIVE_ORG_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function setStoredOrgId(orgId: string) {
+  try {
+    window.localStorage.setItem(ACTIVE_ORG_STORAGE_KEY, orgId);
+  } catch {
+    // ignore
+  }
+
+  // Also mirror to cookie so server actions/SSR can read if needed.
+  document.cookie = `sns_active_org_id=${encodeURIComponent(orgId)}; path=/; SameSite=Lax`;
+}
+
+export function OrgProvider({ children }: { children: React.ReactNode }) {
+  const { data, error, isLoading } = useSWR<{ data: OrgSummary[] }>(
+    "/api/orgs",
+    (url: string) => apiFetch<{ data: OrgSummary[] }>(url),
+  );
+
+  const orgs = React.useMemo(() => data?.data ?? [], [data]);
+  const [activeOrgId, setActiveOrgIdState] = React.useState<string | null>(
+    null,
+  );
+
+  React.useEffect(() => {
+    const stored = getStoredOrgId();
+    if (stored) setActiveOrgIdState(stored);
+  }, []);
+
+  React.useEffect(() => {
+    if (!activeOrgId && orgs.length > 0) {
+      const nextId = orgs[0]?.id;
+      if (nextId) {
+        setActiveOrgIdState(nextId);
+        setStoredOrgId(nextId);
+      }
+    }
+  }, [activeOrgId, orgs]);
+
+  const activeOrg = orgs.find((o) => o.id === activeOrgId) ?? orgs[0] ?? null;
+
+  const setActiveOrgId = React.useCallback((orgId: string) => {
+    setActiveOrgIdState(orgId);
+    setStoredOrgId(orgId);
+  }, []);
+
+  return (
+    <OrgContext.Provider
+      value={{
+        orgs,
+        activeOrg,
+        setActiveOrgId,
+        isLoading,
+        error: error instanceof Error ? error.message : null,
+      }}
+    >
+      {children}
+    </OrgContext.Provider>
+  );
+}
+
+/**
+ * Access current organization scope in dashboard UI.
+ */
+export function useOrg() {
+  const ctx = React.useContext(OrgContext);
+  if (!ctx) {
+    throw new Error("useOrg must be used within OrgProvider");
+  }
+  return ctx;
+}

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -1,0 +1,46 @@
+import * as React from "react";
+import * as AvatarPrimitive from "@radix-ui/react-avatar";
+
+import { cn } from "@/lib/utils";
+
+export const Avatar = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Root
+    ref={ref}
+    className={cn(
+      "relative flex h-8 w-8 shrink-0 overflow-hidden rounded-full border border-zinc-200 bg-zinc-50",
+      className,
+    )}
+    {...props}
+  />
+));
+Avatar.displayName = AvatarPrimitive.Root.displayName;
+
+export const AvatarImage = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Image>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Image>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Image
+    ref={ref}
+    className={cn("aspect-square h-full w-full", className)}
+    {...props}
+  />
+));
+AvatarImage.displayName = AvatarPrimitive.Image.displayName;
+
+export const AvatarFallback = React.forwardRef<
+  React.ElementRef<typeof AvatarPrimitive.Fallback>,
+  React.ComponentPropsWithoutRef<typeof AvatarPrimitive.Fallback>
+>(({ className, ...props }, ref) => (
+  <AvatarPrimitive.Fallback
+    ref={ref}
+    className={cn(
+      "flex h-full w-full items-center justify-center rounded-full bg-zinc-100 text-xs font-medium text-zinc-700",
+      className,
+    )}
+    {...props}
+  />
+));
+AvatarFallback.displayName = AvatarPrimitive.Fallback.displayName;

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,0 +1,33 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const badgeVariants = cva(
+  "inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium",
+  {
+    variants: {
+      variant: {
+        default: "border-zinc-200 bg-zinc-50 text-zinc-700",
+        secondary: "border-zinc-200 bg-white text-zinc-900",
+        success: "border-emerald-200 bg-emerald-50 text-emerald-800",
+        warning: "border-amber-200 bg-amber-50 text-amber-800",
+        destructive: "border-red-200 bg-red-50 text-red-800",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  },
+);
+
+export interface BadgeProps
+  extends
+    React.HTMLAttributes<HTMLSpanElement>,
+    VariantProps<typeof badgeVariants> {}
+
+export function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <span className={cn(badgeVariants({ variant, className }))} {...props} />
+  );
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,52 @@
+import * as React from "react";
+import { Slot } from "@radix-ui/react-slot";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        default: "bg-zinc-900 text-white hover:bg-zinc-800",
+        secondary: "bg-zinc-100 text-zinc-900 hover:bg-zinc-200",
+        outline:
+          "border border-zinc-200 bg-transparent text-zinc-900 hover:bg-zinc-100",
+        ghost: "bg-transparent text-zinc-900 hover:bg-zinc-100",
+        destructive: "bg-red-600 text-white hover:bg-red-700",
+      },
+      size: {
+        default: "h-9 px-4 py-2",
+        sm: "h-8 px-3",
+        lg: "h-10 px-6",
+        icon: "h-9 w-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  },
+);
+
+export interface ButtonProps
+  extends
+    React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button";
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = "Button";

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,69 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Card = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("rounded-lg border border-zinc-200 bg-white", className)}
+    {...props}
+  />
+));
+Card.displayName = "Card";
+
+export const CardHeader = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "flex flex-col gap-1.5 border-b border-zinc-100 p-4",
+      className,
+    )}
+    {...props}
+  />
+));
+CardHeader.displayName = "CardHeader";
+
+export const CardTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm font-semibold", className)} {...props} />
+));
+CardTitle.displayName = "CardTitle";
+
+export const CardDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm text-zinc-500", className)} {...props} />
+));
+CardDescription.displayName = "CardDescription";
+
+export const CardContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("p-4", className)} {...props} />
+));
+CardContent.displayName = "CardContent";
+
+export const CardFooter = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn(
+      "flex items-center justify-end gap-2 border-t border-zinc-100 p-4",
+      className,
+    )}
+    {...props}
+  />
+));
+CardFooter.displayName = "CardFooter";

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,94 @@
+import * as React from "react";
+import * as DialogPrimitive from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export const Dialog = DialogPrimitive.Root;
+export const DialogTrigger = DialogPrimitive.Trigger;
+export const DialogPortal = DialogPrimitive.Portal;
+export const DialogClose = DialogPrimitive.Close;
+
+export const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/50 backdrop-blur-[1px]",
+      className,
+    )}
+    {...props}
+  />
+));
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
+
+export const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-1/2 top-1/2 z-50 w-[calc(100vw-2rem)] max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-lg border border-zinc-200 bg-white p-6 shadow-lg",
+        className,
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close
+        className="absolute right-4 top-4 rounded-md p-1 text-zinc-500 hover:bg-zinc-100 hover:text-zinc-900"
+        aria-label="Close"
+      >
+        <X className="h-4 w-4" />
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+));
+DialogContent.displayName = DialogPrimitive.Content.displayName;
+
+export const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div className={cn("flex flex-col gap-1.5", className)} {...props} />
+);
+DialogHeader.displayName = "DialogHeader";
+
+export const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-4 flex items-center justify-end gap-2", className)}
+    {...props}
+  />
+);
+DialogFooter.displayName = "DialogFooter";
+
+export const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn("text-base font-semibold", className)}
+    {...props}
+  />
+));
+DialogTitle.displayName = DialogPrimitive.Title.displayName;
+
+export const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-zinc-500", className)}
+    {...props}
+  />
+));
+DialogDescription.displayName = DialogPrimitive.Description.displayName;

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,120 @@
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+export const DropdownMenu = DropdownMenuPrimitive.Root;
+export const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+export const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+export const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+export const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+export const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+export const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[10rem] overflow-hidden rounded-md border border-zinc-200 bg-white p-1 shadow-md",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+export const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-zinc-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+export const DropdownMenuCheckboxItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.CheckboxItem>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.CheckboxItem>
+>(({ className, children, checked, ...props }, ref) => (
+  <DropdownMenuPrimitive.CheckboxItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-zinc-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    checked={checked}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.CheckboxItem>
+));
+DropdownMenuCheckboxItem.displayName =
+  DropdownMenuPrimitive.CheckboxItem.displayName;
+
+export const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-zinc-100", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export const DropdownMenuSubTrigger = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
+    inset?: boolean;
+  }
+>(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-zinc-100 data-[state=open]:bg-zinc-100",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto h-4 w-4 text-zinc-500" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName =
+  DropdownMenuPrimitive.SubTrigger.displayName;
+
+export const DropdownMenuSubContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 min-w-[10rem] overflow-hidden rounded-md border border-zinc-200 bg-white p-1 shadow-md",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName =
+  DropdownMenuPrimitive.SubContent.displayName;

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Input = React.forwardRef<
+  HTMLInputElement,
+  React.InputHTMLAttributes<HTMLInputElement>
+>(({ className, type, ...props }, ref) => (
+  <input
+    ref={ref}
+    type={type}
+    className={cn(
+      "flex h-9 w-full rounded-md border border-zinc-200 bg-white px-3 py-1 text-sm shadow-sm placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+Input.displayName = "Input";

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Label = React.forwardRef<
+  HTMLLabelElement,
+  React.LabelHTMLAttributes<HTMLLabelElement>
+>(({ className, ...props }, ref) => (
+  <label
+    ref={ref}
+    className={cn("text-sm font-medium leading-none", className)}
+    {...props}
+  />
+));
+Label.displayName = "Label";

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -1,0 +1,75 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Table = React.forwardRef<
+  HTMLTableElement,
+  React.TableHTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="w-full overflow-auto">
+    <table
+      ref={ref}
+      className={cn("w-full caption-bottom text-sm", className)}
+      {...props}
+    />
+  </div>
+));
+Table.displayName = "Table";
+
+export const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+));
+TableHeader.displayName = "TableHeader";
+
+export const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+));
+TableBody.displayName = "TableBody";
+
+export const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn(
+      "border-b border-zinc-100 transition-colors hover:bg-zinc-50",
+      className,
+    )}
+    {...props}
+  />
+));
+TableRow.displayName = "TableRow";
+
+export const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "h-10 px-3 text-left align-middle font-medium text-zinc-500",
+      className,
+    )}
+    {...props}
+  />
+));
+TableHead.displayName = "TableHead";
+
+export const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td ref={ref} className={cn("p-3 align-middle", className)} {...props} />
+));
+TableCell.displayName = "TableCell";

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export const Textarea = React.forwardRef<
+  HTMLTextAreaElement,
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>
+>(({ className, ...props }, ref) => (
+  <textarea
+    ref={ref}
+    className={cn(
+      "flex min-h-[120px] w-full rounded-md border border-zinc-200 bg-white px-3 py-2 text-sm shadow-sm placeholder:text-zinc-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-zinc-900/10 disabled:cursor-not-allowed disabled:opacity-50",
+      className,
+    )}
+    {...props}
+  />
+));
+Textarea.displayName = "Textarea";

--- a/src/lib/api/fetcher.ts
+++ b/src/lib/api/fetcher.ts
@@ -1,0 +1,48 @@
+/**
+ * Small fetch wrapper for Next.js App Router API routes.
+ * Adds org scoping header when provided.
+ */
+export async function apiFetch<T>(
+  input: string,
+  init?: RequestInit & { orgId?: string },
+): Promise<T> {
+  const headers = new Headers(init?.headers);
+  if (init?.orgId) {
+    headers.set("X-Org-Id", init.orgId);
+  }
+
+  const res = await fetch(input, {
+    ...init,
+    headers,
+    credentials: "include",
+  });
+
+  if (!res.ok) {
+    let message = `Request failed: ${res.status}`;
+    try {
+      const data = (await res.json()) as { error?: string };
+      if (data?.error) message = data.error;
+    } catch {
+      // ignore
+    }
+    throw new Error(message);
+  }
+
+  return (await res.json()) as T;
+}
+
+export async function apiPost<TResponse, TBody>(
+  input: string,
+  body: TBody,
+  init?: Omit<RequestInit, "method" | "body"> & { orgId?: string },
+): Promise<TResponse> {
+  return apiFetch<TResponse>(input, {
+    ...init,
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {}),
+    },
+    body: JSON.stringify(body),
+  });
+}

--- a/src/lib/api/org-scope.ts
+++ b/src/lib/api/org-scope.ts
@@ -1,0 +1,60 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import type { OrgRole } from "@/types/organization";
+
+export type OrgAuthContext = {
+  supabase: Awaited<ReturnType<typeof createSupabaseServerClient>>;
+  orgId: string;
+  userId: string;
+  role: OrgRole;
+};
+
+/**
+ * Extract org_id from query or header and validate membership.
+ * Returns either an OrgAuthContext or a NextResponse error.
+ */
+export async function requireOrgScope(
+  request: NextRequest,
+): Promise<OrgAuthContext | NextResponse> {
+  const supabase = await createSupabaseServerClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json(
+      { error: "Unauthorized", code: "UNAUTHORIZED" },
+      { status: 401 },
+    );
+  }
+
+  const orgId =
+    request.nextUrl.searchParams.get("org_id") ||
+    request.headers.get("X-Org-Id");
+  if (!orgId) {
+    return NextResponse.json(
+      {
+        error: "org_id query parameter or X-Org-Id header is required",
+        code: "MISSING_ORG_ID",
+      },
+      { status: 400 },
+    );
+  }
+
+  const { data: membership } = await supabase
+    .from("sns_org_members")
+    .select("role")
+    .eq("org_id", orgId)
+    .eq("user_id", user.id)
+    .single();
+
+  if (!membership) {
+    return NextResponse.json(
+      { error: "Not a member of this organization", code: "FORBIDDEN" },
+      { status: 403 },
+    );
+  }
+
+  return { supabase, orgId, userId: user.id, role: membership.role as OrgRole };
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,10 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/**
+ * Tailwind className utility.
+ * Combines conditional classes and resolves Tailwind conflicts.
+ */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}


### PR DESCRIPTION
## Summary
- Implement Phase 2 UI screens: Analytics Dashboard, Multi-tenant Organization Settings, and AI Studio generation.
- Add dashboard layout + workspace switcher and org-scoped data fetching.
- Add analytics and streaming generation API routes needed by the UI.

## Test plan
- [ ] Run `pnpm lint`
- [ ] Run `pnpm build`
- [ ] Visit `/posts` and switch workspace in header dropdown
- [ ] Visit `/settings/organization` and verify member list/invite/role change (owner/admin only)
- [ ] Visit `/analytics` and confirm range toggle + charts render
- [ ] Visit `/generate`, generate drafts (streaming), save draft, request approval

closes #10
closes #11
closes #12

Made with [Cursor](https://cursor.com)